### PR TITLE
Resource exists check

### DIFF
--- a/lib/rspec-puppet/matchers/create_resource.rb
+++ b/lib/rspec-puppet/matchers/create_resource.rb
@@ -15,7 +15,7 @@ module RSpec::Puppet
           ret = false
         end
 
-        if @expected_params
+        if @expected_params and resources.length != 0
           @expected_params.each do |name, value|
             unless resources.first.send(:parameters)[name.to_sym] == value
               ret = false


### PR DESCRIPTION
Previously, I was seeing the error
undefined method `parameters' for nil:NilClass in
cases where with_param was specified for resources
that did not exist in the catalog.

This patch will not check the chained params if
the resource does not exist.

Reviewed-by: Jeff McCune
