### PR TITLE
Added support.rb to rspec-puppet.gemspec.

### DIFF
--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
     'lib/rspec-puppet/example/class_example_group.rb',
     'lib/rspec-puppet/example/define_example_group.rb',
     'lib/rspec-puppet/example.rb',
+    'lib/rspec-puppet/support.rb',
     'lib/rspec-puppet/matchers/create_generic.rb',
     'lib/rspec-puppet/matchers/create_resource.rb',
     'lib/rspec-puppet/matchers/include_class.rb',


### PR DESCRIPTION
As noted by kbarber in https://github.com/puppetlabs/rspec-puppet/commit/cb7722fac3d0f3f2dea4511a72483c7966754a3a#commitcomment-515126, this is needed for the gem to build properly.
