### PR TITLE
Issue/master/remove faces call

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -1,5 +1,5 @@
 module RSpec::Puppet
-  module Support 
+  module Support
     def build_catalog nodename, facts_val
       node_obj = Puppet::Node.new(nodename)
 
@@ -9,8 +9,7 @@ module RSpec::Puppet
       if Puppet::Resource::Catalog.respond_to? :find
         Puppet::Resource::Catalog.find(node_obj.name, :use_node => node_obj)
       else
-        require 'puppet/face'
-        Puppet::Face[:catalog, :current].find(node_obj.name, :use_node => node_obj)
+        Puppet::Resource::Catalog.indirection.find(node_obj.name, :use_node => node_obj)
       end
     end
   end


### PR DESCRIPTION
Previously, used the catalog face for
compilation with the :use_node option.

Starting in 2.7.2rc2, all faces options
must be explicit, so the catalog face
no longer supports the use_node option.

This commit changes the call to use
the indirection directly.
