### PR TITLE
Add setting to use custom Facter implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,20 @@ In some circumstances (e.g. where your nodename/certname is not the same as
 your FQDN), this behaviour is undesirable and can be disabled by changing this
 setting to `false`.
 
+#### facter\_implementation
+Type    | Default  | Puppet Version(s)
+------- | -------- | -----------------
+String  | `facter` | 6.25+, 7.12+
+
+Configures rspec-puppet to use a specific Facter implementation for running
+unit tests. If the `rspec` implementation is set and Puppet does not support
+it, rspec-puppet will warn and fall back to the `facter` implementation.
+Setting an unsupported option will make rspec-puppet raise an error.
+
+ * `facter` - Use the default implementation, honoring the Facter version specified in the Gemfile
+ * `rspec` - Use a custom hash-based implementation of Facter defined in
+   rspec-puppet (this provides a considerable gain in speed if tests are run with Facter 4)
+
 ## Naming conventions
 
 For clarity and consistency, I recommend that you use the following directory

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -43,6 +43,7 @@ RSpec.configure do |c|
   c.add_setting :default_node_params, :default => {}
   c.add_setting :default_trusted_facts, :default => {}
   c.add_setting :default_trusted_external_data, :default => {}
+  c.add_setting :facter_implementation, :default => 'facter'
   c.add_setting :hiera_config, :default => Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
   c.add_setting :parser, :default => 'current'
   c.add_setting :trusted_node_data, :default => false

--- a/lib/rspec-puppet/facter_impl.rb
+++ b/lib/rspec-puppet/facter_impl.rb
@@ -1,0 +1,49 @@
+module RSpec::Puppet
+
+  # Implements a simple hash-based version of Facter to be used in module tests
+  # that use rspec-puppet.
+  class FacterTestImpl
+    def initialize
+      @facts = {}
+    end
+
+    def value(fact_name)
+      @facts[fact_name.to_s]
+    end
+
+    def clear
+      @facts.clear
+    end
+
+    def to_hash
+      @facts
+    end
+
+    def add(name, options = {}, &block)
+      raise 'Facter.add expects a block' unless block_given?
+      @facts[name.to_s] = instance_eval(&block)
+    end
+
+    # noop methods
+    def debugging(arg); end
+
+    def reset; end
+
+    def search(*paths); end
+
+    def setup_logging; end
+
+    private
+
+    def setcode(string = nil, &block)
+      if block_given?
+        value = block.call
+      else
+        value = string
+      end
+
+      value
+    end
+  end
+end
+

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -337,7 +337,7 @@ module RSpec::Puppet
       {"servername" => "fqdn",
         "serverip" => "ipaddress"
       }.each do |var, fact|
-        if value = Facter.value(fact)
+        if value = FacterImpl.value(fact)
           server_facts[var] = value
         else
           warn "Could not retrieve fact #{fact}"
@@ -345,8 +345,8 @@ module RSpec::Puppet
       end
 
       if server_facts["servername"].nil?
-        host = Facter.value(:hostname)
-        if domain = Facter.value(:domain)
+        host = FacterImpl.value(:hostname)
+        if domain = FacterImpl.value(:domain)
           server_facts["servername"] = [host, domain].join(".")
         else
           server_facts["servername"] = host
@@ -478,8 +478,8 @@ module RSpec::Puppet
 
     def stub_facts!(facts)
       Puppet.settings[:autosign] = false if Puppet.settings.include? :autosign
-      Facter.clear
-      facts.each { |k, v| Facter.add(k, :weight => 999) { setcode { v } } }
+      FacterImpl.clear
+      facts.each { |k, v| FacterImpl.add(k, :weight => 999) { setcode { v } } }
     end
 
     def build_catalog(*args)

--- a/spec/unit/facter_impl_spec.rb
+++ b/spec/unit/facter_impl_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require 'rspec-puppet/facter_impl'
+
+describe RSpec::Puppet::FacterTestImpl do
+  subject(:facter_impl) { RSpec::Puppet::FacterTestImpl.new }
+  let(:fact_hash) do
+    {
+      'string_fact' => 'string_value',
+      'hash_fact' => { 'key' => 'value' },
+      'int_fact' => 3,
+      'true_fact' => true,
+      'false_fact' => false,
+    }
+  end
+
+  before do
+    facter_impl.add(:string_fact) { setcode { 'string_value' } }
+    facter_impl.add(:hash_fact) { setcode { { 'key' => 'value' } } }
+    facter_impl.add(:int_fact) { setcode { 3 } }
+    facter_impl.add(:true_fact) { setcode { true } }
+    facter_impl.add(:false_fact) { setcode { false } }
+  end
+
+  describe 'noop methods' do
+    [:debugging, :reset, :search, :setup_logging].each do |method|
+      it "implements ##{method}" do
+        expect(facter_impl).to respond_to(method)
+      end
+    end
+  end
+
+  describe '#value' do
+    it 'retrieves a fact of type String' do
+      expect(facter_impl.value(:string_fact)).to eq('string_value')
+    end
+
+    it 'retrieves a fact of type Hash' do
+      expect(facter_impl.value(:hash_fact)).to eq({ 'key' => 'value' })
+    end
+
+    it 'retrieves a fact of type Integer' do
+      expect(facter_impl.value(:int_fact)).to eq(3)
+    end
+
+    it 'retrieves a fact of type TrueClass' do
+      expect(facter_impl.value(:true_fact)).to eq(true)
+    end
+
+    it 'retrieves a fact of type FalseClass' do
+      expect(facter_impl.value(:false_fact)).to eq(false)
+    end
+  end
+
+  describe '#to_hash' do
+    it 'returns a hash with all added facts' do
+      expect(facter_impl.to_hash).to eq(fact_hash)
+    end
+  end
+
+  describe '#clear' do
+    it 'clears the fact hash' do
+      facter_impl.clear
+      expect(facter_impl.to_hash).to be_empty
+    end
+  end
+
+  describe '#add' do
+    before { facter_impl.clear }
+
+    it 'adds a fact with a setcode block' do
+      facter_impl.add(:setcode_block) { setcode { 'value' } }
+      expect(facter_impl.value(:setcode_block)).to eq('value')
+    end
+
+    it 'adds a fact with a setcode string' do
+      facter_impl.add(:setcode_string) { setcode 'value' }
+      expect(facter_impl.value(:setcode_string)).to eq('value')
+    end
+
+    it 'fails when not given a block' do
+      expect { facter_impl.add(:something) }.to raise_error(RuntimeError, 'Facter.add expects a block')
+    end
+  end
+end


### PR DESCRIPTION
Starting with versions 7.12.0/6.25.0, Puppet was changed not to directly
depend on Facter anymore, but to use a `Puppet::Runtime` implementation
instead (e.g. calls to `Facter` were changed to
`Puppet.runtime[:facter]` to allow for pluggable Facter backends).

rspec-puppet stubs facts from facterdb by setting custom facts with
higher weights, meaning that Facter 4 will still resolve the underlying
core facts (which is by design), leading to noticeable performance hits
when compiling catalogs with Facter 4 as opposed to Facter 2 (which just
returned the custom fact).

This means we can achieve a pretty big performance improvement with
rspec-puppet by registering a custom Facter implementation that bypasses
Facter altogether and just saves facts to hash.

This behavior cand be activated by setting `facter_implementation` to
`rspec` in `RSpec.configure`. By default, the setting has the value of
`facter` which maintains the old behavior of going through Facter.