### PR TITLE
Ensure FacterImpl consistency between example groups

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -43,7 +43,7 @@ RSpec.configure do |c|
   c.add_setting :default_node_params, :default => {}
   c.add_setting :default_trusted_facts, :default => {}
   c.add_setting :default_trusted_external_data, :default => {}
-  c.add_setting :facter_implementation, :default => 'facter'
+  c.add_setting :facter_implementation, :default => :facter
   c.add_setting :hiera_config, :default => Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
   c.add_setting :parser, :default => 'current'
   c.add_setting :trusted_node_data, :default => false

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -113,12 +113,16 @@ module RSpec::Puppet
       #
       # @api private
       #
-      # Set the FacterImpl constant to the given Facter implementation.
-      # The method noops if the constant is already set
+      # Set the FacterImpl constant to the given Facter implementation or noop
+      # if the constant is already set. If a proc is given, it will only be
+      # called if FacterImpl is not defined.
       #
-      # @param impl [Object]
+      # @param impl [Object, Proc] An object or a proc that implements the Facter API
       def set_facter_impl(impl)
-        Object.send(:const_set, :FacterImpl, impl) unless defined? FacterImpl
+        return if defined?(FacterImpl)
+
+        impl = impl.call if impl.is_a?(Proc)
+        Object.send(:const_set, :FacterImpl, impl)
       end
 
       def setup_puppet(example_group)
@@ -237,7 +241,9 @@ module RSpec::Puppet
         case RSpec.configuration.facter_implementation.to_sym
         when :rspec
           if supports_facter_runtime?
-            set_facter_impl(RSpec::Puppet::FacterTestImpl.new)
+            # Lazily instantiate FacterTestImpl here to optimize memory
+            # allocation, as the proc will only be called if FacterImpl is unset
+            set_facter_impl(proc { RSpec::Puppet::FacterTestImpl.new })
             Puppet.runtime[:facter] = FacterImpl
           else
             warn "Facter runtime implementations are not supported in Puppet #{Puppet.version}, continuing with facter_implementation 'facter'"

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -247,7 +247,7 @@ module RSpec::Puppet
             Puppet.runtime[:facter] = FacterImpl
           else
             warn "Facter runtime implementations are not supported in Puppet #{Puppet.version}, continuing with facter_implementation 'facter'"
-            RSpec.configuration.facter_implementation = 'facter'
+            RSpec.configuration.facter_implementation = :facter
             set_facter_impl(Facter)
           end
         when :facter

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -237,8 +237,8 @@ module RSpec::Puppet
         case RSpec.configuration.facter_implementation.to_sym
         when :rspec
           if supports_facter_runtime?
-            Puppet.runtime[:facter] = proc { RSpec::Puppet::FacterTestImpl.new }
-            set_facter_impl(Puppet.runtime[:facter])
+            set_facter_impl(RSpec::Puppet::FacterTestImpl.new)
+            Puppet.runtime[:facter] = FacterImpl
           else
             warn "Facter runtime implementations are not supported in Puppet #{Puppet.version}, continuing with facter_implementation 'facter'"
             RSpec.configuration.facter_implementation = 'facter'

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -224,6 +224,18 @@ describe RSpec::Puppet::Adapters::Adapter6X, :if => Puppet::Util::Package.versio
         expect(FacterImpl).to be_kind_of(RSpec::Puppet::FacterTestImpl)
       end
 
+      it 'ensures consistency of FacterImpl in subsequent example groups' do
+        context = context_double
+
+        # Pretend that FacterImpl is already initialized from a previous example group
+        Puppet.runtime[:facter] = RSpec::Puppet::FacterTestImpl.new
+        Object.send(:const_set, :FacterImpl, Puppet.runtime[:facter])
+
+        allow(RSpec.configuration).to receive(:facter_implementation).and_return('rspec')
+        subject.setup_puppet(context)
+        expect(FacterImpl).to eq(Puppet.runtime[:facter])
+      end
+
       it 'raises if given an unsupported option' do
         context = context_double
         allow(RSpec.configuration).to receive(:facter_implementation).and_return('salam')


### PR DESCRIPTION
Using the 'rspec' facter implementation we could sometimes get in a case where the values of `FacterImpl` and `Puppet.runtime[:facter]` diverged between example groups.

Because rspec-puppet overrides facts using the `FacterImpl` constant (which is only set once), `Puppet.runtime[:facter]` would point to a different instance of `FacterTestImpl` with no available facts, causing calls to `Puppet.runtime[:facter].value` to fail.

To prevent this from happening, attempt to set `Puppet.runtime[:facter]` to the value of `FacterImpl` if available, this way we make sure `Puppet.runtime[:facter]` and `FacterImpl` operate on the same instance of `FacterTestImpl`.