### PR TITLE
Use platform stubs when testing a rspec_puppet_example

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -163,11 +163,11 @@ module Puppet
 
       def path_to_uri(*args)
         if RSpec::Puppet.rspec_puppet_example?
+          old_path_to_uri(*args)
+        else
           RSpec::Puppet::Consts.without_stubs do
             old_path_to_uri(*args)
           end
-        else
-          old_path_to_uri(*args)
         end
       end
       module_function :path_to_uri


### PR DESCRIPTION
Hello,

I'm facing a problem when specifying such a puppet `file` resource for a Windows agent, and running the tests on a Unix machine : 

```puppet
file { "C:/my-local-copy.txt":
    ensure  => file,
    source  => "C:/local-file.txt"
  }
```

Without the suggested changes, I get the following error : 
```
error during compilation: Parameter source failed on File[C:/my-local-copy.txt]: Failed to convert 'C:/local-file.txt' to URI: bad component(expected absolute path component): C:/local-file.txt
```
