### PR TITLE
Add the ability to use `kind_of` matchers

### DIFF
--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -35,6 +35,8 @@ module RSpec::Puppet
             case @expected_return
             when Regexp
               return !!(@actual_return =~ @expected_return)
+            when RSpec::Mocks::ArgumentMatchers::KindOf, RSpec::Matchers::AliasedMatcher
+              return @expected_return === @actual_return
             else
               return @actual_return == @expected_return
             end


### PR DESCRIPTION
This allows you to check the return type of functions, like this
example:

```
is_expected.to run.with_params('mymod/template.epp', { 'foo' => 'bar' }).and_return(kind_of String)
```
