### PR TITLE
(GH-CAT-98) - Adding CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Setting ownership to the modules team
+* @puppetlabs/modules


### PR DESCRIPTION
Prior to this commit the CODEOWNERS file for this repository did not exist.

Since the efforts of this team have been merged in to CaT (modules) this
commit adds the associated group to https://github.com/orgs/puppetlabs/teams/modules.