### PR TITLE
Add a transitive test property

### DIFF
--- a/spec/classes/relationship__notify_spec.rb
+++ b/spec/classes/relationship__notify_spec.rb
@@ -17,4 +17,7 @@ describe 'relationships::notify' do
 
   it { should contain_notify('pre').that_notifies(['Notify[post]']) }
   it { should contain_notify('post').that_subscribes_to(['Notify[pre]']) }
+
+  # TODO: in practice this transitive notification doesn't work
+  it { should contain_service('myservice').that_subscribes_to('File[/tmp/file.txt]') }
 end

--- a/spec/fixtures/modules/relationships/manifests/notify.pp
+++ b/spec/fixtures/modules/relationships/manifests/notify.pp
@@ -15,6 +15,10 @@ class relationships::notify {
   class { '::relationships::notify::pre': } ~>
   class { '::relationships::notify::middle': } ~>
   class { '::relationships::notify::post': }
+
+  file { '/tmp/file.txt': } ~>
+  file { '/tmp/directory': } ~>
+  service { 'myservice': }
 }
 
 class relationships::notify::pre {


### PR DESCRIPTION
This is a minimal reproducer that's essentially A ~> B ~> C. The that_subscribes_to matcher shows that this is equal to A ~> C but in practice Puppet doesn't work that way. The service is not restarted if the file is modified.

I don't know what is the expected behavior here, but it does mean that today it's not possible to test for real world behavior.

It was first opened as https://github.com/rodjek/rspec-puppet/pull/821 but that repo was forked. Then I opened https://github.com/puppetlabs/rspec-puppet/pull/29 but it was closed due to a change of the default branch so here is attempt number 3.