### PR TITLE
Add include_legacy_facts setting

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -60,6 +60,7 @@ RSpec.configure do |c|
   c.add_setting :fixture_hiera_configs, :default => {}
   c.add_setting :use_fixture_spec_hiera, :default => false
   c.add_setting :fallback_to_default_hiera, :default => true
+  c.add_setting :include_legacy_facts, :default => true
 
   c.instance_eval do
     def trusted_server_facts

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -169,6 +169,7 @@ module RSpec::Puppet
           [:hiera_config, :hiera_config],
           [:strict_variables, :strict_variables],
           [:manifest, :manifest],
+          [:include_legacy_facts, :include_legacy_facts],
         ])
       end
 
@@ -263,6 +264,7 @@ module RSpec::Puppet
         super.concat([
           [:basemodulepath, :basemodulepath],
           [:vendormoduledir, :vendormoduledir],
+          [:include_legacy_facts, :include_legacy_facts],
         ])
       end
 

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -204,6 +204,11 @@ describe RSpec::Puppet::Adapters::Adapter6X, :if => Puppet::Util::Package.versio
 
   let(:test_context) { double :environment => 'rp_env' }
 
+  it 'sets Puppet[:strict_variables] to false by default' do
+    subject.setup_puppet(test_context)
+    expect(Puppet[:include_legacy_facts]).to eq(true)
+  end
+
   describe '#setup_puppet' do
     describe 'when managing the facter_implementation' do
       after(:each) do


### PR DESCRIPTION
Well it is my first PR here. I hope this is correct. Please tell if I need to change anything.

I would like to enable the setting `include_legacy_facts`. We would like to be able to test the code for legacy facts since we already would like to make our code puppet 8 compatible.

Default value would be `true` and could be changed via:
```
RSpec.configure do |config|
  ##
  ## disable legacy facts
  ##
  config.include_legacy_facts = false
end
```