### PR TITLE
(MAINT) Fix gem env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
         ruby_version:
           - "2.7"
           - "3.2"
-        puppet_gem_version:
-          - '~> 7.0'
-          - 'https://github.com/puppetlabs/puppet' # puppet8
+        include:
+          - ruby-version: '2.7'
+            puppet_gem_version: '~> 7.0'
+          - ruby_version: '3.2'
+            puppet_gem_version: 'https://github.com/puppetlabs/puppet' # puppet8'
         runs_on:
           - "ubuntu-latest"
           - "windows-latest"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,11 +11,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - "2.5"
           - "2.7"
-        puppet_gem_version:
-          - '~> 6.0'
-          - '~> 7.0'
+          - "3.2"
+        include:
+          - ruby-version: '2.7'
+            puppet_gem_version: '~> 7.0'
+          - ruby_version: '3.2'
+            puppet_gem_version: 'https://github.com/puppetlabs/puppet' # puppet8'
         runs_on:
           - "ubuntu-latest"
           - "windows-latest"

--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ end
 
 group :test do
 
-  gem 'puppet', *location_for(ENV['PUPPET_LOCATION'])
-  gem 'facter', *location_for(ENV['FACTER_LOCATION'])
+  gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
+  gem 'facter', *location_for(ENV['FACTER_GEM_VERSION'])
 
   gem 'json_pure'
   gem 'sync'


### PR DESCRIPTION
For CI and to keep in line with modules, we should use `*_GEM_VERSION` environment variables in the gem file.