### PR TITLE
Avoid hardcoding ipaddress6 default

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -241,9 +241,17 @@ module RSpec::Puppet
         'hostname' => node.split('.').first,
         'fqdn' => node,
         'domain' => node.split('.', 2).last,
-        'clientcert' => node,
-        'ipaddress6' => 'FE80:0000:0000:0000:AAAA:AAAA:AAAA'
+        'clientcert' => node
       }
+
+      # Puppet 6.9.0 started setting a `serverip6` server fact which is set
+      # using the value of the `ipaddress6` fact. If the fact set(s) provided
+      # by FacterDB don't have an `ipaddress6` fact set, then the normal Facter
+      # fact will be resolved, which can result in Ruby trying to load Windows
+      # only gems on Linux. This is only a problem if facter is used.
+      if RSpec.configuration.facter_implementation.to_sym == :facter
+        node_facts['ipaddress6'] = 'FE80:0000:0000:0000:AAAA:AAAA:AAAA'
+      end
 
       networking_facts = {
         'hostname' => node_facts['hostname'],


### PR DESCRIPTION
## Summary

In 4ef2f3643eaab642d2f24ffda6a507699d9ae0a8 this was added as a workaround, but in 48c56051047667ff6f7f3915d7597e2da669e26d a custom Facter implementation was added. This avoids any calls to the real Facter and doesn't suffer from the issue where it was attempting to load Windows gems on Linux.

## Additional Context

- [x] Root cause and the steps to reproduce.
- [x] Thought process behind the implementation.

## Related Issues (if any)

Fixes #15

## Checklist

- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.