### PR TITLE
Drop RSpec 2 & Ruby 1 compatiblity

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ require 'puppet'
 task :default => :test
 task :spec => :test
 
-require 'rspec-puppet/tasks/release_test' unless RUBY_VERSION.start_with?('1')
+require 'rspec-puppet/tasks/release_test'
 
 fixtures_dir = File.expand_path(File.join(__FILE__, '..', 'spec', 'fixtures', 'modules'))
 fixtures = {

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -11,15 +11,10 @@ end
 
 class RSpec::Puppet::EventListener
   def self.example_started(example)
-    if rspec3?
-      @rspec_puppet_example = example.example.example_group.ancestors.include?(RSpec::Puppet::Support)
-      @current_example = example.example
-      if !@current_example.respond_to?(:environment) && @current_example.respond_to?(:example_group_instance)
-        @current_example = @current_example.example_group_instance
-      end
-    else
-      @rspec_puppet_example = example.example_group.ancestors.include?(RSpec::Puppet::Support)
-      @current_example = example
+    @rspec_puppet_example = example.example.example_group.ancestors.include?(RSpec::Puppet::Support)
+    @current_example = example.example
+    if !@current_example.respond_to?(:environment) && @current_example.respond_to?(:example_group_instance)
+      @current_example = @current_example.example_group_instance
     end
   end
 
@@ -37,12 +32,6 @@ class RSpec::Puppet::EventListener
 
   def self.rspec_puppet_example?
     @rspec_puppet_example || false
-  end
-
-  def self.rspec3?
-    @rspec3 = defined?(RSpec::Core::Notifications) if @rspec3.nil?
-
-    @rspec3
   end
 
   class << self

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -13,9 +13,9 @@ class RSpec::Puppet::EventListener
   def self.example_started(example)
     @rspec_puppet_example = example.example.example_group.ancestors.include?(RSpec::Puppet::Support)
     @current_example = example.example
-    if !@current_example.respond_to?(:environment) && @current_example.respond_to?(:example_group_instance)
-      @current_example = @current_example.example_group_instance
-    end
+    return unless !@current_example.respond_to?(:environment) && @current_example.respond_to?(:example_group_instance)
+
+    @current_example = @current_example.example_group_instance
   end
 
   def self.example_passed(_example)

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -508,14 +508,6 @@ module RSpec::Puppet
       string.gsub('$', '\\$')
     end
 
-    def rspec_compatibility
-      return unless RSpec::Version::STRING < '3'
-
-      # RSpec 2 compatibility:
-      alias_method :failure_message_for_should, :failure_message
-      alias_method :failure_message_for_should_not, :failure_message_when_negated
-    end
-
     def fixture_spec_hiera_conf(mod)
       return @@fixture_hiera_configs[mod.name] if @@fixture_hiera_configs.key?(mod.name)
 

--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['CHANGELOG.md', 'LICENSE.md', 'README.md', 'lib/**/*', 'bin/**/*']
 
-  s.add_dependency 'rspec'
+  s.add_dependency 'rspec', '~> 3.0'
 
   s.authors = ['Tim Sharpe', 'Puppet, Inc.', 'Community Contributors']
   s.email = ['tim@sharpe.id.au', 'modules-team@puppet.com']

--- a/spec/classes/test_windows_spec.rb
+++ b/spec/classes/test_windows_spec.rb
@@ -5,10 +5,6 @@ require 'spec_helper'
 describe 'test::windows' do
   let(:facts) { { operatingsystem: 'windows' } }
 
-  let(:symlink_path) do
-    RUBY_VERSION == '1.8.7' ? 'C:\\\\something.txt' : 'C:\\something.txt'
-  end
-
   it { is_expected.to compile.with_all_deps }
-  it { is_expected.to contain_file(symlink_path) }
+  it { is_expected.to contain_file('C:\\something.txt') }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,23 +14,15 @@ end
 
 require 'rspec-puppet'
 
-# rspec 2.x doesn't have RSpec::Support, so fall back to File::ALT_SEPARATOR to
-# detect if running on windows
+# TODO: drop?
 def windows?
   return @windowsp unless @windowsp.nil?
 
-  @windowsp = defined?(RSpec::Support) ? RSpec::Support::OS.windows? : !!File::ALT_SEPARATOR
+  @windowsp = RSpec::Support::OS.windows?
 end
 
 def sensitive?
   defined?(Puppet::Pops::Types::PSensitiveType)
-end
-
-module Helpers
-  def rspec2?
-    RSpec::Version::STRING < '3'
-  end
-  module_function :rspec2?
 end
 
 RSpec.configure do |c|
@@ -43,7 +35,4 @@ RSpec.configure do |c|
   c.after(:suite) do
     RSpec::Puppet::Coverage.report!(0)
   end
-
-  c.include Helpers
-  c.extend Helpers
 end

--- a/spec/spec_helper_unit.rb
+++ b/spec/spec_helper_unit.rb
@@ -13,37 +13,3 @@ if ENV['COVERAGE']
 end
 
 require 'rspec-puppet'
-
-module Helpers
-  def rspec2?
-    RSpec::Version::STRING < '3'
-  end
-  module_function :rspec2?
-
-  def test_double(type, *args)
-    if rspec2?
-      double(type.to_s, *args)
-    else
-      instance_double(type, *args)
-    end
-  end
-end
-
-RSpec.configure do |c|
-  c.include Helpers
-  c.extend Helpers
-
-  if Helpers.rspec2?
-    RSpec::Matchers.define :be_truthy do
-      match do |actual|
-        !actual.nil? == true
-      end
-    end
-
-    RSpec::Matchers.define :be_falsey do
-      match do |actual|
-        !actual.nil? == false
-      end
-    end
-  end
-end

--- a/spec/unit/matchers/count_generic_spec.rb
+++ b/spec/unit/matchers/count_generic_spec.rb
@@ -6,12 +6,12 @@ describe RSpec::Puppet::ManifestMatchers::CountGeneric do
   subject(:matcher) { described_class.new(type, expected, method) }
 
   let(:actual) do
-    -> { test_double(Puppet::Resource::Catalog, resources: resource_objects) }
+    -> { instance_double(Puppet::Resource::Catalog, resources: resource_objects) }
   end
 
   let(:resource_objects) do
     resources.map do |type, title|
-      test_double(Puppet::Resource, ref: "#{type}[#{title}]", type: type)
+      instance_double(Puppet::Resource, ref: "#{type}[#{title}]", type: type)
     end
   end
 

--- a/spec/unit/matchers/include_class_spec.rb
+++ b/spec/unit/matchers/include_class_spec.rb
@@ -6,7 +6,7 @@ describe 'RSpec::Puppet::ManifestMatchers.include_class' do
   subject(:matcher) { Class.new { extend RSpec::Puppet::ManifestMatchers }.include_class(expected) }
 
   let(:actual) do
-    -> { test_double(Puppet::Resource::Catalog, classes: included_classes) }
+    -> { instance_double(Puppet::Resource::Catalog, classes: included_classes) }
   end
 
   let(:expected) { 'test_class' }
@@ -44,31 +44,14 @@ describe 'RSpec::Puppet::ManifestMatchers.include_class' do
     end
   end
 
-  describe '#failure_message_for_should', if: rspec2? do
-    it 'provides a description and the expected class' do
-      matcher.matches?(actual)
-      expect(matcher.failure_message_for_should).to eq("expected that the catalogue would include Class[#{expected}]")
-    end
-  end
-
-  describe '#failure_message', unless: rspec2? do
+  describe '#failure_message' do
     it 'provides a description and the expected class' do
       matcher.matches?(actual)
       expect(matcher.failure_message).to eq("expected that the catalogue would include Class[#{expected}]")
     end
   end
 
-  describe '#failure_message_for_should_not', if: rspec2? do
-    let(:included_classes) { [expected] }
-
-    it 'provides a description and the expected class' do
-      pending 'not implemented'
-      matcher.matches?(actual)
-      expect(matcher.failure_message_when_negated).to eq("expected that the catalogue would not include Class[#{expected}]")
-    end
-  end
-
-  describe '#failure_message_when_negated', unless: rspec2? do
+  describe '#failure_message_when_negated' do
     let(:included_classes) { [expected] }
 
     it 'provides a description and the expected class' do

--- a/spec/unit/matchers/run_spec.rb
+++ b/spec/unit/matchers/run_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper_unit'
 describe RSpec::Puppet::FunctionMatchers::Run do
   subject(:matcher) { described_class.new }
 
-  let(:wrapper) { test_double(RSpec::Puppet::FunctionExampleGroup::V4FunctionWrapper) }
+  let(:wrapper) { instance_double(RSpec::Puppet::FunctionExampleGroup::V4FunctionWrapper) }
 
   describe '#matches?' do
     context 'when the function takes no arguments and has no expected return value' do


### PR DESCRIPTION
Ruby 1 support was already dropped, but some code remained. By now we can assume everyone has migrated to RSpec 3 so dropping compatibility with RSpec 2 is safe. It may not even run on Ruby 2.7.