### PR TITLE
Raise minimum version to Puppet 7.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,34 +18,15 @@
 
     gem install rspec-puppet
 
-> Note for ruby 1.8 users:  while rspec-puppet itself supports ruby 1.8, you'll
-> need to pin rspec itself to `~> 3.1.0`, as later rspec versions do not work
-> on old rubies anymore.
-
 ## Starting out with a new module
 
 When you start out on a new module, create a metadata.json file for your module and then run `rspec-puppet-init` to create the necessary files to configure rspec-puppet for your module's tests.
 
-
-## Configure manifests for Puppet 4
-
-With Puppet 3, the manifest is set to `$manifestdir/site.pp`. However Puppet 4 defaults to an empty value. In order to test manifests you will need to set appropriate settings.
-
-Puppet configuration reference for `manifest` can be found online:
-
-* Puppet 3: https://docs.puppet.com/puppet/3.8/reference/configuration.html#manifest
-* Puppet 4: https://docs.puppet.com/puppet/4.8/reference/configuration.html#manifest
-
 Configuration is typically done in a `spec/spec_helper.rb` file which each of your spec will require. Example code:
 ```ruby
-# /spec
-base_dir = File.dirname(File.expand_path(__FILE__))
-
 RSpec.configure do |c|
-  c.module_path     = File.join(base_dir, 'fixtures', 'modules')
-  c.manifest_dir    = File.join(base_dir, 'fixtures', 'manifests')
-  c.manifest        = File.join(base_dir, 'fixtures', 'manifests', 'site.pp')
-  c.environmentpath = File.join(Dir.pwd, 'spec')
+  c.module_path     = File.join(__dir__, 'fixtures', 'modules')
+  c.environmentpath = __dir__
 
   # Coverage generation
   c.after(:suite) do
@@ -65,54 +46,46 @@ RSpec.configure do |c|
 end
 ```
 
-#### manifest\_dir
-Type   | Default  | Puppet Version(s)
------- | -------- | -----------------
-String | Required | 2.x, 3.x
-
-The path to the directory containing your basic manifests like `site.pp`.
-
 #### module\_path
 Type   | Default  | Puppet Version(s)
 ------ | -------- | ------------------
-String | Required | 2.x, 3.x, 4.x, 5.x
+String | Required | any
 
 The path to the directory containing your Puppet modules.
 
 #### default\_facts
 Type | Default | Puppet Version(s)
 ---- | ------- | ------------------
-Hash | `{}`    | 2.x, 3.x, 4.x, 5.x
+Hash | `{}`    | any
 
 A hash of default facts that should be used for all the tests.
 
 #### hiera\_config
 Type   | Default       | Puppet Version(s)
 ------ | ------------- | -----------------
-String | `"/dev/null"` | 3.x, 4.x, 5.x
+String | `"/dev/null"` | any
 
 The path to your `hiera.yaml` file (if used).
 
 #### default\_node\_params
 Type | Default | Puppet Version(s)
 ---- | ------- | -----------------
-Hash | `{}`    | 4.x, 5.x
+Hash | `{}`    | any
 
 A hash of default node parameters that should be used for all the tests.
 
 #### default\_trusted\_facts
 Type | Default | Puppet Version(s)
 ---- | ------- | -----------------
-Hash | `{}`    | 4.x, 5.x
+Hash | `{}`    | any
 
 A hash of default trusted facts that should be used for all the tests
-(available in the manifests as the `$trusted` hash). In order to use this, the
-`trusted_node_data` setting must be set to `true`.
+(available in the manifests as the `$trusted` hash).
 
 #### trusted\_node\_data
 Type    | Default | Puppet Version(s)
 ------- | ------- | -----------------
-Boolean | `false` | >=3.4, 4.x, 5.x
+Boolean | `false` | any
 
 Configures rspec-puppet to use the `$trusted` hash when compiling the
 catalogues.
@@ -120,7 +93,7 @@ catalogues.
 #### trusted\_server\_facts
 Type    | Default | Puppet Version(s)
 ------- | ------- | -----------------
-Boolean | `false` | >=4.3, 5.x
+Boolean | `false` | any
 
 Configures rspec-puppet to use the `$server_facts` hash when compiling the
 catalogues.
@@ -128,62 +101,28 @@ catalogues.
 #### confdir
 Type   | Default         | Puppet Version(s)
 ------ | --------------- | ------------------
-String | `"/etc/puppet"` | 2.x, 3.x, 4.x, 5.x
+String | `"/etc/puppet"` | any
 
 The path to the main Puppet configuration directory.
 
 #### config
 Type   | Default                | Puppet Version(s)
 ------ | ---------------------- | ------------------
-String | Puppet's default value | 2.x, 3.x, 4.x, 5.x
+String | Puppet's default value | any
 
 The path to `puppet.conf`.
-
-#### manifest
-Type   | Default                | Puppet Version(s)
------- | ---------------------- | -----------------
-String | Puppet's default value | 2.x, 3.x
-
-The entry-point manifest for Puppet, usually `$manifest_dir/site.pp`.
-
-#### template\_dir
-Type   | Default | Puppet Version(s)
------- | ------- | -----------------
-String | `nil`   | 2.x, 3.x
-
-The path to the directory that Puppet should search for templates that are
-stored outside of modules.
 
 #### environmentpath
 Type   | Default                               | Puppet Version(s)
 ------ | ------------------------------------- | -----------------
-String | `"/etc/puppetlabs/code/environments"` | 4.x, 5.x
+String | `"/etc/puppetlabs/code/environments"` | any
 
 The search path for environment directories.
-
-#### parser
-Type   | Default     | Puppet Version(s)
------- | ----------- | -----------------
-String | `"current"` | >= 3.2
-
-This switches between the 3.x (`current`) and 4.x (`future`) parsers.
-
-#### ordering
-Type   | Default        | Puppet Version(s)
------- | -------------- | -----------------
-String | `"title-hash"` | >= 3.3, 4.x, 5.x
-
-How unrelated resources should be ordered when applying a catalogue.
- * `manifest` - Use the order in which the resources are declared in the
-   manifest.
- * `title-hash` - Order the resources randomly, but in a consistent manner
-   across runs (the order will only change if the manifest changes).
- * `random` - Order the resources randomly.
 
 #### strict\_variables
 Type    | Default | Puppet Version(s)
 ------- | ------- | -----------------
-Boolean | `false` | >= 3.5, 4.x, 5.x
+Boolean | `false` | any
 
 Makes Puppet raise an error when it tries to reference a variable that hasn't
 been defined (not including variables that have been explicitly set to
@@ -192,7 +131,7 @@ been defined (not including variables that have been explicitly set to
 #### stringify\_facts
 Type    | Default | Puppet Version(s)
 ------- | ------- | -----------------
-Boolean | `true`  | >= 3.3, 4.x, 5.x
+Boolean | `true`  | any
 
 Makes rspec-puppet coerce all the fact values into strings (matching the
 behaviour of older versions of Puppet).
@@ -200,7 +139,7 @@ behaviour of older versions of Puppet).
 #### enable\_pathname\_stubbing
 Type    | Default | Puppet Version(s)
 ------- | ------- | ------------------
-Boolean |`false`  | 2.x, 3.x, 4.x, 5.x
+Boolean |`false`  | any
 
 Configures rspec-puppet to stub out `Pathname#absolute?` with it's own
 implementation. This should only be enabled if you're running into an issue
@@ -210,7 +149,7 @@ functions, etc) that use `Pathname#absolute?`.
 #### setup\_fixtures
 Type    | Default | Puppet Version(s)
 ------- | ------- | ------------------
-Boolean | `true`  | 2.x, 3.x, 4.x, 5.x
+Boolean | `true`  | any
 
 Configures rspec-puppet to automatically create a link from the root of your
 module to `spec/fixtures/<module name>` at the beginning of the test run.
@@ -218,7 +157,7 @@ module to `spec/fixtures/<module name>` at the beginning of the test run.
 #### derive\_node\_facts\_from\_nodename
 Type    | Default | Puppet Version(s)
 ------- | ------- | -----------------
-Boolean | `true`  | 2.x, 3.x, 4.x, 5.x
+Boolean | `true`  | any
 
 If `true`, rspec-puppet will override the `fdqn`, `hostname`, and `domain`
 facts with values that it derives from the node name (specified with
@@ -231,7 +170,7 @@ setting to `false`.
 #### facter\_implementation
 Type    | Default  | Puppet Version(s)
 ------- | -------- | -----------------
-String  | `facter` | 6.25+, 7.12+
+String  | `facter` | any
 
 Configures rspec-puppet to use a specific Facter implementation for running
 unit tests. If the `rspec` implementation is set and Puppet does not support
@@ -695,8 +634,6 @@ RSpec.configure do |c|
 end
 ```
 
-**NOTE** Setting top-scope variables is not supported in Puppet < 3.0.
-
 #### Specifying extra code to load (pre-conditions)
 
 If the manifest being tested relies on another class or variables to be set, these can be added via
@@ -748,7 +685,7 @@ let(:module_path) { '/path/to/your/module/dir' }
 
 #### Specifying trusted facts
 
-When testing with Puppet >= 4.3 the trusted facts hash will have the standard trusted fact keys
+The trusted facts hash will have the standard trusted fact keys
 (certname, domain, and hostname) populated based on the node name (as set with `:node`).
 
 By default, the test environment contains no custom trusted facts (as usually obtained
@@ -773,8 +710,7 @@ end
 
 #### Specifying trusted external data
 
-When testing with Puppet >= 6.14, the trusted facts hash will have an additional `external`
-key for trusted external data.
+The trusted facts hash will have an `external` key for trusted external data.
 
 By default, the test environment contains no trusted external data (as usually obtained from
 trusted external commands and found in the `external` key). If you need to test against specific

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ require 'puppet'
 task :default => :test
 task :spec => :test
 
-require 'rspec-puppet/tasks/release_test' unless RUBY_VERSION.start_with?('1')
+require 'rspec-puppet/tasks/release_test'
 
 fixtures_dir = File.expand_path(File.join(__FILE__, '..', 'spec', 'fixtures', 'modules'))
 fixtures = {

--- a/docs/documentation/configuration/index.md
+++ b/docs/documentation/configuration/index.md
@@ -19,15 +19,10 @@ end
 {% endhighlight %}
 
 ## Required settings
-### manifest\_dir
-**Type:** String<br />
-**Puppet Version(s):** 2.x, 3.x
-
-The path to the directory containing your basic manifests like `site.pp`.
 
 ### module\_path
 **Type:** String<br />
-**Puppet Version(s):** 2.x, 3.x, 4.x, 5.x
+**Puppet Version(s):** any
 
 The path to the directory containing the Puppet modules.
 
@@ -35,44 +30,36 @@ The path to the directory containing the Puppet modules.
 ### default\_facts
 **Type:** Hash<br />
 **Default:** None<br />
-**Puppet Version(s):** 2.x, 3.x, 4.x, 5.x
+**Puppet Version(s):** any
 
 A hash of default facts that should be used for all the tests.
 
 ### hiera\_config
 **Type:** String<br />
 **Default:** `/dev/null`<br />
-**Puppet Version(s):** 3.x, 4.x, 5.x
+**Puppet Version(s):** any
 
 The path to your `hiera.yaml` file (if used).
 
 ### default\_node\_params
 **Type:** Hash<br />
 **Default:** None<br />
-**Puppet Version(s):** 4.x, 5.x
+**Puppet Version(s):** any
 
 A hash of default node parameters that should be used for all the tests.
 
 ### default\_trusted\_facts
 **Type:** Hash<br />
 **Default:** None<br />
-**Puppet Version(s):** 4.x, 5.x
+**Puppet Version(s):** any
 
 A hash of default trusted facts that should be used for all the tests
-(available in the manifests as `$trusted`). In order to use this,
-`trusted_node_data` must also be set to `true`.
-
-### trusted\_node\_data
-**Type:** Boolean<br />
-**Default:** `false`<br />
-**Puppet Version(s):** ~> 3.4, 4.x, 5.x
-
-Makes rspec-puppet use the `$trusted` hash when testing catalogues.
+(available in the manifests as `$trusted`).
 
 ### setup\_fixtures
 **Type:** Boolean<br />
 **Default:** `true`<br />
-**Puppet Version(s):** 2.x, 3.x, 4.x, 5.x
+**Puppet Version(s):** any
 
 Configures rspec-puppet to automatically create a link from the root of your
 module to `spec/fixtures/<module name>` at the beginning of the test run.
@@ -80,7 +67,7 @@ module to `spec/fixtures/<module name>` at the beginning of the test run.
 ### trusted\_server\_facts
 **Type:** Boolean<br />
 **Default:** `false`<br />
-**Puppet Version(s):** >= 4.3, 5.x
+**Puppet Version(s):** any
 
 Configures rspec-puppet to use the `$server_facts` hash when compiling the
 catalogues.
@@ -92,7 +79,7 @@ determining the values itself, but if you need to override them you can.
 ### confdir
 **Type:** String<br />
 **Default:** `/etc/puppet`<br />
-**Puppet Version(s):** 2.x, 3.x, 4.x, 5.x
+**Puppet Version(s):** any
 
 The path to the main Puppet configuration directory.
 
@@ -103,40 +90,17 @@ for further details.
 ### config
 **Type:** String<br />
 **Default:** Puppet's default value<br />
-**Puppet Version(s):** 2.x, 3.x, 4.x, 5.x
+**Puppet Version(s):** any
 
 The path to `puppet.conf`.
 
 See the [Puppet documentation](https://docs.puppet.com/puppet/latest/configuration.html#config)
 for further details.
 
-### manifest
-**Type:** String<br />
-**Default:** Puppet's default value<br />
-**Puppet Version(s):** 2.x, 3.x
-
-The entry-point manifest for Puppet, usually `<manifest_dir>/site.pp`.
-
-See the [Puppet
-documentation](https://docs.puppet.com/puppet/latest/configuration.html#manifest)
-for further details.
-
-### template\_dir
-**Type**: String<br />
-**Default:** None<br />
-**Puppet Version(s):** 2.x, 3.x
-
-The path to the directory that Puppet should search for templates stored
-outside of modules.
-
-See the [Puppet
-documentation](https://docs.puppet.com/puppet/3.8/deprecated_settings.html#templatedir)
-for further details.
-
 ### environmentpath
 **Type:** String<br />
 **Default:** `/etc/puppetlabs/code/environments`<br />
-**Puppet Version(s):** 4.x, 5.x
+**Puppet Version(s):** any
 
 The search path for environment directories.
 
@@ -144,38 +108,10 @@ See the [Puppet
 documentation](https://docs.puppet.com/puppet/latest/configuration.html#environmentpath)
 for further details.
 
-### parser
-**Type:** String<br />
-**Default:** `current`<br />
-**Puppet Version(s):** ~> 3.2
-
-This switches between the 3.x (`current`) and 4.x (`future`) parsers.
-
-See the [Puppet
-documentation](https://docs.puppet.com/puppet/3.8/deprecated_settings.html#parser)
-for further details.
-
-### ordering
-**Type:** String<br />
-**Default:** `title-hash`<br />
-**Puppet Version(s):** ~> 3.3, 4.x, 5.x
-
-How unrelated resources should be ordered when applying a catalogue.
- * `manifest` - Use the order in which the resources are declared in the
-   manifest.
- * `title-hash` - Order the resources randomly, but in a consistent manner
-   across runs (the order will only change if the code changes).
- * `random` - Order the resources randomly (ideal for finding resources that
-   do not have explicit dependencies).
-
-See the [Puppet
-documentation](https://docs.puppet.com/puppet/latest/configuration.html#ordering)
-for further details.
-
 ### strict\_variables
 **Type:** Boolean<br />
 **Default:** `false`<br />
-**Puppet Version(s):** ~> 3.5, 4.x, 5.x
+**Puppet Version(s):** any
 
 Makes Puppet raise an error when it tries to reference a variable that hasn't
 been defined (not including variables that have been explicitly set to
@@ -184,7 +120,7 @@ been defined (not including variables that have been explicitly set to
 ### stringify\_facts
 **Type:** Boolean<br />
 **Default:** `true`<br />
-**Puppet Version(s):** ~> 3.3, 4.x, 5.x
+**Puppet Version(s):** any
 
 Makes rspec-puppet coerce all the fact values into strings (matching the
 behaviour of older versions of Puppet).
@@ -192,7 +128,7 @@ behaviour of older versions of Puppet).
 ### enable\_pathname\_stubbing
 **Type:** Boolean<br />
 **Default:** `false`<br />
-**Puppet Version(s):** 2.x, 3.x, 4.x, 5.x
+**Puppet Version(s):** any
 
 Configures rspec-puppet to stub out `Pathname#absolute?` with its own
 implementation. This should only be enabled if you're running into an issue
@@ -202,7 +138,7 @@ functions, etc) that use `Pathname#absolute?`.
 ### derive\_node\_facts\_from\_nodename
 **Type:** Boolean<br />
 **Default:** `true`<br />
-**Puppet Version(s):** 2.x, 3.x, 4.x, 5.x
+**Puppet Version(s):** any
 
 If `true`, rspec-puppet will override the `fdqn`, `hostname`, and `domain`
 facts with values that it derives from the node name (specified with
@@ -215,7 +151,7 @@ setting to `false`.
 ### vendormoduledir
 **Type:** String<br />
 **Default:** `'/dev/null'` (or `'c:/nul/'` on Windows)
-**Puppet Version(s):** 6.x
+**Puppet Version(s):** any
 
 The path to the directory containing vendored modules. Almost always
 unnecessary in a testing environment.
@@ -223,7 +159,7 @@ unnecessary in a testing environment.
 ### basemodulepath
 **Type:** String<br />
 **Default:** `'/dev/null'` (or `'c:/nul/'` on Windows)
-**Puppet Version(s):** 6.x
+**Puppet Version(s):** any
 
 The search path for global modules. Almost always unnecessary in a testing
 environment.
@@ -231,7 +167,7 @@ environment.
 ### disable_module_hiera
 **Type:** Boolean<br />
 **Default:** `false`<br />
-**Puppet Version(s):** 4.9+, 5.x, 6.x
+**Puppet Version(s):** any
 
 Enabling this will prevent Puppet from using module-layer Hiera data entirely.
 This includes the module being tested as well as any fixture modules.
@@ -240,7 +176,7 @@ The end effect is that only Hiera data from the global `:hiera_config` parameter
 ### fixture_hiera_configs
 **Type:** Hash<br />
 **Default:** `{}`<br />
-**Puppet Version(s):** 4.9+, 5.x, 6.x
+**Puppet Version(s):** any
 
 A hash of module names and their respective module-layer Hiera config file paths.
 This can be used to override the path to the module-layer hiera.yaml
@@ -248,14 +184,14 @@ This can be used to override the path to the module-layer hiera.yaml
 ### use_fixture_spec_hiera
 **Type:** Boolean<br />
 **Default:** `false`<br />
-**Puppet Version(s):** 4.9+, 5.x, 6.x
+**Puppet Version(s):** any
 
 Enabling this will prevent Puppet from using the module-layer Hiera config file and instead search the module spec folder for a file named hiera.yaml.
 
 ### fallback_to_default_hiera
 **Type:** Boolean<br />
 **Default:** `true`<br />
-**Puppet Version(s):** 4.9+, 5.x, 6.x
+**Puppet Version(s):** any
 
 A hash of module names and their respective module-layer Hiera config file paths.
 This can be used to override the path to the module-layer hiera.yaml.

--- a/docs/documentation/coverage/index.md
+++ b/docs/documentation/coverage/index.md
@@ -56,16 +56,6 @@ If this percentage is not achieved, a test failure will be raised.
 Resources declared outside of the module being tested (i.e. resources added by
 module dependencies) are automatically excluded from the coverage report.
 
-<div class="callout-block callout-info">
-<div class="icon-holder"><i class="fa fa-info-circle"></i></div>
-<div class="content">
-Prior to Puppet 4.6.0, resources created by functions
-(<code>create_resources</code>, <code>ensure_packages</code> etc) did not have
-the required information in them to determine which manifest they came from and
-so can not be excluded from the coverage report.
-</div>
-</div>
-
 To exclude other resources from the coverage reports, for example to avoid `anchor`s,
 use the `add_filter(type, title)` and `add_filter_regex(type, regex)` methods:
 

--- a/docs/documentation/setup/index.md
+++ b/docs/documentation/setup/index.md
@@ -82,11 +82,9 @@ content.
 {% highlight ruby %}
 require 'rspec-puppet'
 
-fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
-
 RSpec.configure do |c|
-  c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.environmentpath = __dir__
+  c.module_path = File.join(__dir__, 'fixtures', 'modules')
 end
 {% endhighlight %}
 

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -36,9 +36,6 @@ require 'rspec-puppet/monkey_patches'
 RSpec.configure do |c|
   c.add_setting :environmentpath, default: Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
   c.add_setting :module_path, default: nil
-  c.add_setting :manifest_dir, default: nil
-  c.add_setting :manifest, default: nil
-  c.add_setting :template_dir, default: nil
   c.add_setting :config, default: nil
   c.add_setting :confdir, default: Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
   c.add_setting :default_facts, default: {}
@@ -47,9 +44,6 @@ RSpec.configure do |c|
   c.add_setting :default_trusted_external_data, default: {}
   c.add_setting :facter_implementation, default: :facter
   c.add_setting :hiera_config, default: Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
-  c.add_setting :parser, default: 'current'
-  c.add_setting :trusted_node_data, default: false
-  c.add_setting :ordering, default: 'title-hash'
   c.add_setting :stringify_facts, default: true
   c.add_setting :strict_variables, default: false
   c.add_setting :setup_fixtures, default: true
@@ -62,17 +56,6 @@ RSpec.configure do |c|
   c.add_setting :fixture_hiera_configs, default: {}
   c.add_setting :use_fixture_spec_hiera, default: false
   c.add_setting :fallback_to_default_hiera, default: true
-
-  c.instance_eval do
-    def trusted_server_facts
-      @trusted_server_facts.nil? ? false : @trusted_server_facts
-    end
-
-    def trusted_server_facts=(value)
-      @trusted_server_facts = value
-      adapter&.setup_puppet(RSpec::Puppet.current_example)
-    end
-  end
 
   c.before(:all) do
     RSpec::Puppet::Setup.safe_setup_directories(nil, false) if RSpec.configuration.setup_fixtures?

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -12,12 +12,6 @@ module RSpec::Puppet
       # executing RSpec context. When a setting is specified both in the global configuration and in
       # the example group, the setting in the example group is preferred.
       #
-      # @example Configuring a Puppet setting from a global RSpec configuration value
-      #   RSpec.configure do |config|
-      #     config.parser = "future"
-      #   end
-      #   # => Puppet[:parser] will be future
-      #
       # @example Configuring a Puppet setting from within an RSpec example group
       #   RSpec.describe 'my_module::my_class', :type => :class do
       #     let(:module_path) { "/Users/luke/modules" }
@@ -42,6 +36,19 @@ module RSpec::Puppet
       # @param example_group [RSpec::Core::ExampleGroup] The RSpec context to use for local settings
       # @return [void]
       def setup_puppet(example_group)
+        case RSpec.configuration.facter_implementation.to_sym
+        when :rspec
+          # Lazily instantiate FacterTestImpl here to optimize memory
+          # allocation, as the proc will only be called if FacterImpl is unset
+          set_facter_impl(proc { RSpec::Puppet::FacterTestImpl.new })
+        when :facter
+          set_facter_impl(Facter)
+        else
+          raise "Unsupported facter_implementation '#{RSpec.configuration.facter_implementation}'"
+        end
+
+        Puppet.runtime[:facter] = FacterImpl
+
         settings = settings_map.map do |puppet_setting, rspec_setting|
           [puppet_setting, get_setting(example_group, rspec_setting)]
         end.flatten
@@ -56,23 +63,44 @@ module RSpec::Puppet
           end
         end
 
-        if Puppet.settings.respond_to?(:initialize_app_defaults)
-          Puppet.settings.initialize_app_defaults(settings_hash)
+        Puppet.settings.initialize_app_defaults(settings_hash)
 
-          # Forcefully apply the environmentpath setting instead of relying on
-          # the application defaults as Puppet::Test::TestHelper automatically
-          # sets this value as well, overriding our application default
-          Puppet.settings[:environmentpath] = settings_hash[:environmentpath] if settings_hash.key?(:environmentpath)
-        else
-          # Set settings the old way for Puppet 2.x, because that's how
-          # they're defaulted in that version of Puppet::Test::TestHelper and
-          # we won't be able to override them otherwise.
-          settings_hash.each do |setting, value|
-            Puppet.settings[setting] = value
-          end
-        end
+        # Forcefully apply the environmentpath setting instead of relying on
+        # the application defaults as Puppet::Test::TestHelper automatically
+        # sets this value as well, overriding our application default
+        Puppet.settings[:environmentpath] = settings_hash[:environmentpath] if settings_hash.key?(:environmentpath)
 
         @environment_name = example_group.environment
+
+        modulepath = if (rspec_modulepath = RSpec.configuration.module_path)
+                       rspec_modulepath.split(File::PATH_SEPARATOR)
+                     else
+                       Puppet[:environmentpath].split(File::PATH_SEPARATOR).map do |path|
+                         File.join(path, 'fixtures', 'modules')
+                       end
+                     end
+
+        manifest_paths = Puppet[:environmentpath].split(File::PATH_SEPARATOR).map do |path|
+          File.join(path, 'fixtures', 'manifests')
+        end
+
+        manifest = manifest_paths.find do |path|
+          File.exist?(path)
+        end
+
+        manifest ||= Puppet::Node::Environment::NO_MANIFEST
+
+        env = Puppet::Node::Environment.create(@environment_name, modulepath, manifest)
+        loader = Puppet::Environments::Static.new(env)
+
+        Puppet.push_context(
+          {
+            environments: loader,
+            current_environment: env,
+            loaders: Puppet::Pops::Loaders.new(env)
+          },
+          'Setup rspec-puppet environments'
+        )
       end
 
       def get_setting(example_group, rspec_setting)
@@ -84,12 +112,23 @@ module RSpec::Puppet
       end
 
       def catalog(node, exported)
-        if exported
-          # Use the compiler directly to skip the filtering done by the indirector
-          Puppet::Parser::Compiler.compile(node).filter { |r| !r.exported? }
-        else
-          Puppet::Resource::Catalog.indirection.find(node.name, use_node: node)
+        node.environment = current_environment
+        # Override $::environment to workaround PUP-5835, where Puppet otherwise
+        # stores a symbol for the parameter
+        if node.parameters['environment'] != node.parameters['environment'].to_s
+          node.parameters['environment'] = current_environment.name.to_s
         end
+
+        catalog = if exported
+                    # Use the compiler directly to skip the filtering done by the indirector
+                    Puppet::Parser::Compiler.compile(node).filter { |r| !r.exported? }
+                  else
+                    Puppet::Resource::Catalog.indirection.find(node.name, use_node: node)
+                  end
+
+        Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(node.facts, catalog)
+
+        catalog
       end
 
       def current_environment
@@ -99,23 +138,34 @@ module RSpec::Puppet
       def settings_map
         [
           %i[modulepath module_path],
+          %i[basemodulepath basemodulepath],
           %i[config config],
-          %i[confdir confdir]
+          %i[confdir confdir],
+          %i[environmentpath environmentpath],
+          %i[hiera_config hiera_config],
+          %i[strict_variables strict_variables],
+          %i[vendormoduledir vendormoduledir],
         ]
       end
 
+      def current_environment
+        Puppet.lookup(:current_environment)
+      end
+
       def modulepath
-        Puppet[:modulepath].split(File::PATH_SEPARATOR)
+        current_environment.modulepath
       end
 
       # @return [String, nil] The path to the Puppet manifest if it is present and set, nil otherwise.
       def manifest
-        Puppet[:manifest]
+        m = current_environment.manifest
+        if m == Puppet::Node::Environment::NO_MANIFEST
+          nil
+        else
+          m
+        end
       end
-    end
 
-    class Adapter40 < Base
-      #
       # @api private
       #
       # Set the FacterImpl constant to the given Facter implementation or noop
@@ -129,223 +179,11 @@ module RSpec::Puppet
         impl = impl.call if impl.is_a?(Proc)
         Object.send(:const_set, :FacterImpl, impl)
       end
-
-      def setup_puppet(example_group)
-        super
-
-        modulepath = if (rspec_modulepath = RSpec.configuration.module_path)
-                       rspec_modulepath.split(File::PATH_SEPARATOR)
-                     else
-                       Puppet[:environmentpath].split(File::PATH_SEPARATOR).map do |path|
-                         File.join(path, 'fixtures', 'modules')
-                       end
-                     end
-
-        if (rspec_manifest = RSpec.configuration.manifest)
-          manifest = rspec_manifest
-        else
-          manifest_paths = Puppet[:environmentpath].split(File::PATH_SEPARATOR).map do |path|
-            File.join(path, 'fixtures', 'manifests')
-          end
-
-          manifest = manifest_paths.find do |path|
-            File.exist?(path)
-          end
-
-          manifest ||= Puppet::Node::Environment::NO_MANIFEST
-        end
-
-        env = Puppet::Node::Environment.create(@environment_name, modulepath, manifest)
-        loader = Puppet::Environments::Static.new(env)
-
-        Puppet.push_context(
-          {
-            environments: loader,
-            current_environment: env,
-            loaders: (Puppet::Pops::Loaders.new(env) if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0'))
-          },
-          'Setup rspec-puppet environments'
-        )
-      end
-
-      def settings_map
-        super.push(
-          %i[environmentpath environmentpath],
-          %i[hiera_config hiera_config],
-          %i[strict_variables strict_variables],
-          %i[manifest manifest]
-        )
-      end
-
-      def catalog(node, exported)
-        node.environment = current_environment
-        # Override $::environment to workaround PUP-5835, where Puppet otherwise
-        # stores a symbol for the parameter
-        if node.parameters['environment'] != node.parameters['environment'].to_s
-          node.parameters['environment'] =
-            current_environment.name.to_s
-        end
-        super
-      end
-
-      def current_environment
-        Puppet.lookup(:current_environment)
-      end
-
-      def modulepath
-        current_environment.modulepath
-      end
-
-      # Puppet 4.0 specially handles environments that don't have a manifest set, so we check for the no manifest value
-      # and return nil when it is set.
-      #
-      # @return [String, nil] The path to the Puppet manifest if it is present and set, nil otherwise.
-      def manifest
-        m = current_environment.manifest
-        if m == Puppet::Node::Environment::NO_MANIFEST
-          nil
-        else
-          m
-        end
-      end
-    end
-
-    class Adapter4X < Adapter40
-      def setup_puppet(example_group)
-        super
-
-        set_facter_impl(Facter)
-      end
-
-      def settings_map
-        super.push(
-          %i[trusted_server_facts trusted_server_facts]
-        )
-      end
-    end
-
-    class Adapter6X < Adapter40
-      #
-      # @api private
-      #
-      # Check to see if Facter runtime implementations are supported in the
-      # current Puppet version
-      #
-      # @return [Boolean] true if runtime implementations are supported
-      def supports_facter_runtime?
-        unless defined?(@supports_facter_runtime)
-          begin
-            Puppet.runtime[:facter]
-            @supports_facter_runtime = true
-          rescue StandardError
-            @supports_facter_runtime = false
-          end
-        end
-
-        @supports_facter_runtime
-      end
-
-      def setup_puppet(example_group)
-        case RSpec.configuration.facter_implementation.to_sym
-        when :rspec
-          if supports_facter_runtime?
-            # Lazily instantiate FacterTestImpl here to optimize memory
-            # allocation, as the proc will only be called if FacterImpl is unset
-            set_facter_impl(proc { RSpec::Puppet::FacterTestImpl.new })
-            Puppet.runtime[:facter] = FacterImpl
-          else
-            warn "Facter runtime implementations are not supported in Puppet #{Puppet.version}, continuing with facter_implementation 'facter'"
-            RSpec.configuration.facter_implementation = :facter
-            set_facter_impl(Facter)
-          end
-        when :facter
-          set_facter_impl(Facter)
-        else
-          raise "Unsupported facter_implementation '#{RSpec.configuration.facter_implementation}'"
-        end
-
-        super
-      end
-
-      def settings_map
-        super.push(
-          %i[basemodulepath basemodulepath],
-          %i[vendormoduledir vendormoduledir]
-        )
-      end
-
-      def catalog(node, _exported)
-        super.tap do |c|
-          Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(node.facts, c)
-        end
-      end
-    end
-
-    class Adapter30 < Base
-      def settings_map
-        super.push(
-          %i[manifestdir manifest_dir],
-          %i[manifest manifest],
-          %i[templatedir template_dir],
-          %i[hiera_config hiera_config]
-        )
-      end
-    end
-
-    class Adapter32 < Adapter30
-      def settings_map
-        super.push(
-          %i[parser parser]
-        )
-      end
-    end
-
-    class Adapter33 < Adapter32
-      def settings_map
-        super.push(
-          %i[ordering ordering],
-          %i[stringify_facts stringify_facts]
-        )
-      end
-    end
-
-    class Adapter34 < Adapter33
-      def settings_map
-        super.push(
-          %i[trusted_node_data trusted_node_data]
-        )
-      end
-    end
-
-    class Adapter35 < Adapter34
-      def settings_map
-        super.push(
-          %i[strict_variables strict_variables]
-        )
-      end
-    end
-
-    class Adapter27 < Base
-      def settings_map
-        super.push(
-          %i[manifestdir manifest_dir],
-          %i[manifest manifest],
-          %i[templatedir template_dir]
-        )
-      end
     end
 
     def self.get
       [
-        ['6.0', Adapter6X],
-        ['4.1', Adapter4X],
-        ['4.0', Adapter40],
-        ['3.5', Adapter35],
-        ['3.4', Adapter34],
-        ['3.3', Adapter33],
-        ['3.2', Adapter32],
-        ['3.0', Adapter30],
-        ['2.7', Adapter27]
+        ['7.11', Base],
       ].each do |(version, klass)|
         return klass.new if Puppet::Util::Package.versioncmp(Puppet.version, version) >= 0
       end

--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -88,18 +88,16 @@ module RSpec::Puppet
       with_vardir do
         env = adapter.current_environment
 
-        if Puppet.version.to_f >= 4.0
-          context_overrides = compiler.context_overrides
-          func = nil
-          loaders = Puppet.lookup(:loaders)
-          Puppet.override(context_overrides, 'rspec-test scope') do
-            func = V4FunctionWrapper.new(function_name,
-                                         loaders.private_environment_loader.load(:function, function_name), context_overrides)
-            @scope = context_overrides[:global_scope]
-          end
-
-          return func if func.func
+        context_overrides = compiler.context_overrides
+        func = nil
+        loaders = Puppet.lookup(:loaders)
+        Puppet.override(context_overrides, 'rspec-test scope') do
+          func = V4FunctionWrapper.new(function_name,
+                                       loaders.private_environment_loader.load(:function, function_name), context_overrides)
+          @scope = context_overrides[:global_scope]
         end
+
+        return func if func.func
 
         if Puppet::Parser::Functions.function(function_name)
           V3FunctionWrapper.new(function_name, scope.method("function_#{function_name}".intern))
@@ -157,46 +155,28 @@ module RSpec::Puppet
 
       node = build_node(node_name, node_options)
 
-      if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0
-        Puppet.push_context(
-          {
-            trusted_information: Puppet::Context::TrustedInformation.new('remote', node_name, trusted_values)
-          },
-          'Context for spec trusted hash'
-        )
-      end
+      Puppet.push_context(
+        {
+          trusted_information: Puppet::Context::TrustedInformation.new('remote', node_name, trusted_values)
+        },
+        'Context for spec trusted hash'
+      )
 
       compiler = Puppet::Parser::Compiler.new(node)
       compiler.compile
-      if Puppet::Util::Package.versioncmp(Puppet.version, '4.0.0') >= 0
-        loaders = Puppet::Pops::Loaders.new(adapter.current_environment)
-        Puppet.push_context(
-          {
-            loaders: loaders,
-            global_scope: compiler.context_overrides[:global_scope]
-          },
-          'set globals'
-        )
-      end
+      loaders = Puppet::Pops::Loaders.new(adapter.current_environment)
+      Puppet.push_context(
+        {
+          loaders: loaders,
+          global_scope: compiler.context_overrides[:global_scope]
+        },
+        'set globals'
+      )
       compiler
     end
 
     def build_scope(compiler, node_name)
-      if Puppet.version.to_f >= 4.0
-        return compiler.context_overrides[:global_scope]
-      elsif /^2\.[67]/.match?(Puppet.version)
-        # loadall should only be necessary prior to 3.x
-        # Please note, loadall needs to happen first when creating a scope, otherwise
-        # you might receive undefined method `function_*' errors
-        Puppet::Parser::Functions.autoloader.loadall
-        scope = Puppet::Parser::Scope.new(compiler: compiler)
-      else
-        scope = Puppet::Parser::Scope.new(compiler)
-      end
-
-      scope.source = Puppet::Resource::Type.new(:node, node_name)
-      scope.parent = compiler.topscope
-      scope
+      compiler.context_overrides[:global_scope]
     end
 
     def build_node(name, opts = {})

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -256,42 +256,40 @@ module Puppet
     end
   end
 
-  if Puppet::Util::Package.versioncmp(Puppet.version, '4.9.0') >= 0
-    class Module
-      old_hiera_conf_file = instance_method(:hiera_conf_file)
-      define_method(:hiera_conf_file) do
-        if RSpec::Puppet.rspec_puppet_example?
-          if RSpec.configuration.disable_module_hiera
-            return nil
-          elsif RSpec.configuration.fixture_hiera_configs.key?(name)
-            config = RSpec.configuration.fixture_hiera_configs[name]
-            config = File.absolute_path(config, path) unless config.nil?
-            return config
-          elsif RSpec.configuration.use_fixture_spec_hiera
-            config = RSpec::Puppet.current_example.fixture_spec_hiera_conf(self)
-            return config unless config.nil? && RSpec.configuration.fallback_to_default_hiera
-          end
+  class Module
+    old_hiera_conf_file = instance_method(:hiera_conf_file)
+    define_method(:hiera_conf_file) do
+      if RSpec::Puppet.rspec_puppet_example?
+        if RSpec.configuration.disable_module_hiera
+          return nil
+        elsif RSpec.configuration.fixture_hiera_configs.key?(name)
+          config = RSpec.configuration.fixture_hiera_configs[name]
+          config = File.absolute_path(config, path) unless config.nil?
+          return config
+        elsif RSpec.configuration.use_fixture_spec_hiera
+          config = RSpec::Puppet.current_example.fixture_spec_hiera_conf(self)
+          return config unless config.nil? && RSpec.configuration.fallback_to_default_hiera
         end
-        old_hiera_conf_file.bind_call(self)
       end
+      old_hiera_conf_file.bind_call(self)
     end
+  end
 
-    class Pops::Lookup::ModuleDataProvider
-      old_configuration_path = instance_method(:configuration_path)
-      define_method(:configuration_path) do |lookup_invocation|
-        if RSpec::Puppet.rspec_puppet_example?
-          env = lookup_invocation.scope.environment
-          mod = env.module(module_name)
-          unless mod
-            raise Puppet::DataBinding::LookupError,
-                  format(_("Environment '%<env>s', cannot find module '%<module_name>s'"), env: env.name,
-                                                                                           module_name: module_name)
-          end
-
-          return Pathname.new(mod.hiera_conf_file)
+  class Pops::Lookup::ModuleDataProvider
+    old_configuration_path = instance_method(:configuration_path)
+    define_method(:configuration_path) do |lookup_invocation|
+      if RSpec::Puppet.rspec_puppet_example?
+        env = lookup_invocation.scope.environment
+        mod = env.module(module_name)
+        unless mod
+          raise Puppet::DataBinding::LookupError,
+                format(_("Environment '%<env>s', cannot find module '%<module_name>s'"), env: env.name,
+                                                                                         module_name: module_name)
         end
-        old_configuration_path.bind_call(self, lookup_invocation)
+
+        return Pathname.new(mod.hiera_conf_file)
       end
+      old_configuration_path.bind_call(self, lookup_invocation)
     end
   end
 end

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -11,15 +11,10 @@ end
 
 class RSpec::Puppet::EventListener
   def self.example_started(example)
-    if rspec3?
-      @rspec_puppet_example = example.example.example_group.ancestors.include?(RSpec::Puppet::Support)
-      @current_example = example.example
-      if !@current_example.respond_to?(:environment) && @current_example.respond_to?(:example_group_instance)
-        @current_example = @current_example.example_group_instance
-      end
-    else
-      @rspec_puppet_example = example.example_group.ancestors.include?(RSpec::Puppet::Support)
-      @current_example = example
+    @rspec_puppet_example = example.example.example_group.ancestors.include?(RSpec::Puppet::Support)
+    @current_example = example.example
+    if !@current_example.respond_to?(:environment) && @current_example.respond_to?(:example_group_instance)
+      @current_example = @current_example.example_group_instance
     end
   end
 
@@ -37,12 +32,6 @@ class RSpec::Puppet::EventListener
 
   def self.rspec_puppet_example?
     @rspec_puppet_example || false
-  end
-
-  def self.rspec3?
-    @rspec3 = defined?(RSpec::Core::Notifications) if @rspec3.nil?
-
-    @rspec3
   end
 
   class << self

--- a/lib/rspec-puppet/sensitive.rb
+++ b/lib/rspec-puppet/sensitive.rb
@@ -1,53 +1,43 @@
 # frozen_string_literal: true
 
 module RSpec::Puppet
-  if defined?(::Puppet::Pops::Types::PSensitiveType::Sensitive)
-    # A wrapper representing Sensitive data type, eg. in class params.
-    class Sensitive < ::Puppet::Pops::Types::PSensitiveType::Sensitive
-      # Create a new Sensitive object
-      # @param [Object] value to wrap
-      def initialize(value)
-        @value = value
-      end
+  # A wrapper representing Sensitive data type, eg. in class params.
+  class Sensitive < ::Puppet::Pops::Types::PSensitiveType::Sensitive
+    # Create a new Sensitive object
+    # @param [Object] value to wrap
+    def initialize(value)
+      @value = value
+    end
 
-      # @return the wrapped value
-      def unwrap
-        @value
-      end
+    # @return the wrapped value
+    def unwrap
+      @value
+    end
 
-      # @return true
-      def sensitive?
-        true
-      end
+    # @return true
+    def sensitive?
+      true
+    end
 
-      # @return inspect of the wrapped value, inside Sensitive()
-      def inspect
-        "Sensitive(#{@value.inspect})"
-      end
+    # @return inspect of the wrapped value, inside Sensitive()
+    def inspect
+      "Sensitive(#{@value.inspect})"
+    end
 
-      # Check for equality with another value.
-      # If compared to Puppet Sensitive type, it compares the wrapped values.
+    # Check for equality with another value.
+    # If compared to Puppet Sensitive type, it compares the wrapped values.
 
-      # @param other [#unwrap, Object] value to compare to
-      def ==(other)
-        if other.respond_to? :unwrap
-          if unwrap.is_a?(Regexp)
-            unwrap =~ other.unwrap
-          else
-            unwrap == other.unwrap
-          end
+    # @param other [#unwrap, Object] value to compare to
+    def ==(other)
+      if other.respond_to? :unwrap
+        if unwrap.is_a?(Regexp)
+          unwrap =~ other.unwrap
         else
-          super
+          unwrap == other.unwrap
         end
+      else
+        super
       end
     end
-  else
-    # :nocov:
-    class Sensitive
-      def initialize(_value)
-        raise 'The use of the Sensitive data type is not supported by this Puppet version'
-      end
-    end
-    # :nocov:
   end
 end

--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -91,14 +91,8 @@ module RSpec::Puppet
     end
 
     def self.get_module_name_from_file(file)
-      # FIXME: see discussion at
-      # https://github.com/rodjek/rspec-puppet/issues/290
-      if Puppet.version.to_f >= 4.0 || RSpec.configuration.parser == 'future'
-        require 'puppet/pops'
-        p = Puppet::Pops::Parser::Lexer2.new
-      else
-        p = Puppet::Parser::Lexer.new
-      end
+      require 'puppet/pops'
+      p = Puppet::Pops::Parser::Lexer2.new
       module_name = nil
       p.string = File.read(file)
       tokens = p.fullscan

--- a/lib/rspec-puppet/spec_helper.rb
+++ b/lib/rspec-puppet/spec_helper.rb
@@ -2,11 +2,7 @@
 
 require 'rspec-puppet'
 
-fixture_path = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures')
-
 RSpec.configure do |c|
-  c.module_path     = File.join(fixture_path, 'modules')
-  c.manifest_dir    = File.join(fixture_path, 'manifests')
-  c.manifest        = File.join(fixture_path, 'manifests', 'site.pp')
-  c.environmentpath = File.join(Dir.pwd, 'spec')
+  c.module_path     = File.join(__dir__, 'fixtures', 'modules')
+  c.environmentpath = __dir__
 end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -508,14 +508,6 @@ module RSpec::Puppet
       string.gsub('$', '\\$')
     end
 
-    def rspec_compatibility
-      return unless RSpec::Version::STRING < '3'
-
-      # RSpec 2 compatibility:
-      alias_method :failure_message_for_should, :failure_message
-      alias_method :failure_message_for_should_not, :failure_message_when_negated
-    end
-
     def fixture_spec_hiera_conf(mod)
       return @@fixture_hiera_configs[mod.name] if @@fixture_hiera_configs.key?(mod.name)
 

--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['CHANGELOG.md', 'LICENSE.md', 'README.md', 'lib/**/*', 'bin/**/*']
 
-  s.add_dependency 'rspec'
+  s.add_dependency 'rspec', '~> 3.0'
 
   s.authors = ['Tim Sharpe', 'Puppet, Inc.', 'Community Contributors']
   s.email = ['tim@sharpe.id.au', 'modules-team@puppet.com']

--- a/spec/classes/array_spec.rb
+++ b/spec/classes/array_spec.rb
@@ -38,36 +38,16 @@ describe 'structured_data' do
       ] }
     end
 
-    # Puppet 2.6 will automatically flatten nested arrays. If we're going
-    # to be testing recursive data structures, we might as well ensure that
-    # we're still handling numeric values correctly.
-    describe 'on Puppet 2.6', if: Puppet.version =~ /^2\.6/ do
-      it {
-        expect(subject).to contain_structured_data__def('thing').with(
-          { 'data' => [
-            'first',
-            'second',
-            'third',
-            'fourth',
-            5,
-            6
-          ] }
-        )
-      }
-    end
-
-    describe 'on Puppet 2.7 and later', unless: Puppet.version =~ /^2\.6/ do
-      it {
-        expect(subject).to contain_structured_data__def('thing').with(
-          { 'data' => [
-            'first',
-            'second',
-            %w[third fourth],
-            5,
-            6
-          ] }
-        )
-      }
-    end
+    it {
+      expect(subject).to contain_structured_data__def('thing').with(
+        { 'data' => [
+          'first',
+          'second',
+          %w[third fourth],
+          5,
+          6
+        ] }
+      )
+    }
   end
 end

--- a/spec/classes/default_spec.rb
+++ b/spec/classes/default_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'default_test', if: Puppet.version.to_f >= 4.0 do
+describe 'default_test' do
   let(:params) { { value: :default } }
 
   it { is_expected.to compile.with_all_deps }

--- a/spec/classes/deferred_spec.rb
+++ b/spec/classes/deferred_spec.rb
@@ -2,6 +2,6 @@
 
 require 'spec_helper'
 
-describe 'deferred', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') >= 0 do
+describe 'deferred' do
   it { is_expected.to contain_notify('deferred msg').with_message('A STRING') }
 end

--- a/spec/classes/facts_spec.rb
+++ b/spec/classes/facts_spec.rb
@@ -8,7 +8,7 @@ family = 'RedHat'
 # with the description of "Facter should not downcast fact names".  The "mixed case in facts" tests this functionality.
 
 describe 'structured_facts::hash' do
-  context 'symbols and strings in facts', if: Puppet.version.to_f >= 4.0 do
+  context 'symbols and strings in facts' do
     let(:facts) do
       {
         os: {
@@ -23,7 +23,7 @@ describe 'structured_facts::hash' do
     it { is_expected.to contain_notify(family) }
   end
 
-  context 'only symbols in facts', if: Puppet.version.to_f >= 4.0 do
+  context 'only symbols in facts' do
     let(:facts) do
       {
         os: {
@@ -39,7 +39,7 @@ describe 'structured_facts::hash' do
   end
 
   # See note concerning mixed case in facts at the beginning of the file
-  context 'mixed case symbols in facts', if: Puppet.version.to_f >= 4.0 do
+  context 'mixed case symbols in facts' do
     let(:facts) do
       {
         oS: {
@@ -54,7 +54,7 @@ describe 'structured_facts::hash' do
     it { is_expected.to contain_notify(family) }
   end
 
-  context 'only strings in facts', if: Puppet.version.to_f >= 4.0 do
+  context 'only strings in facts' do
     let(:facts) do
       {
         'os' => {
@@ -70,7 +70,7 @@ describe 'structured_facts::hash' do
   end
 
   # See note concerning mixed case in facts at the beginning of the file
-  context 'mixed case strings in facts', if: Puppet.version.to_f >= 4.0 do
+  context 'mixed case strings in facts' do
     let(:facts) do
       {
         'oS' => {
@@ -166,7 +166,7 @@ describe 'structured_facts::top_scope' do
 end
 
 describe 'structured_facts::case_check' do
-  context 'mixed case in structure fact nested keys', if: Puppet.version.to_f >= 4.0 do
+  context 'mixed case in structure fact nested keys' do
     let(:facts) do
       {
         'custom_fact' => {

--- a/spec/classes/hash_spec.rb
+++ b/spec/classes/hash_spec.rb
@@ -20,21 +20,11 @@ describe 'structured_data' do
       { 'data' => { 1 => 'uno', 2 => 'dos' } }
     end
 
-    context 'puppet less than 4', unless: Puppet.version.to_f >= 4.0 do
-      it {
-        expect(subject).to contain_structured_data__def('thing').with(
-          { 'data'  => { '1' => 'uno', '2' => 'dos' } }
-        )
-      }
-    end
-
-    context 'puppet 4 or greater', if: Puppet.version.to_f >= 4.0 do
-      it {
-        expect(subject).to contain_structured_data__def('thing').with(
-          { 'data'  => { 1 => 'uno', 2 => 'dos' } }
-        )
-      }
-    end
+    it {
+      expect(subject).to contain_structured_data__def('thing').with(
+        { 'data'  => { 1 => 'uno', 2 => 'dos' } }
+      )
+    }
   end
 
   describe 'with integers as values' do

--- a/spec/classes/hiera_integration_spec.rb
+++ b/spec/classes/hiera_integration_spec.rb
@@ -2,8 +2,7 @@
 
 require 'spec_helper'
 
-# hiera is not supported before 2.7
-describe 'test::hiera', if: Puppet.version.to_f >= 3.0 do
+describe 'test::hiera' do
   context 'with :hiera_config set' do
     let(:hiera_config) { 'spec/fixtures/hiera.yaml' }
 
@@ -15,7 +14,7 @@ describe 'test::hiera', if: Puppet.version.to_f >= 3.0 do
   end
 end
 
-describe 'hiera_test', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.9.0') >= 0 do
+describe 'hiera_test' do
   before do
     RSpec.configuration.disable_module_hiera = false
     RSpec.configuration.use_fixture_spec_hiera = false
@@ -106,7 +105,7 @@ describe 'hiera_test', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.9
   end
 end
 
-describe 'hiera_test2', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.9.0') >= 0 do
+describe 'hiera_test2' do
   before do
     RSpec.configuration.disable_module_hiera = false
     RSpec.configuration.use_fixture_spec_hiera = false

--- a/spec/classes/map_reduce_spec.rb
+++ b/spec/classes/map_reduce_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'map_reduce', if: (Puppet.version.to_f >= 4.0 || RSpec.configuration.parser == 'future') do
+describe 'map_reduce' do
   let(:params) do
     {
       values: [0, 1, 2]

--- a/spec/classes/node_params_spec.rb
+++ b/spec/classes/node_params_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'node_params', if: Puppet::Util::Package.versioncmp(Puppet.version, '3.0.0') >= 0 do
+describe 'node_params' do
   fuzzed = {
     string: 'foo bar baz',
     hash: { 'foo' => 'bar', 'baz' => 'foo' },
@@ -27,7 +27,7 @@ describe 'node_params', if: Puppet::Util::Package.versioncmp(Puppet.version, '3.
     end
   end
 
-  it "doesn't leak to the facts hash", if: Puppet::Util::Package.versioncmp(Puppet.version, '4.0.0') >= 0 do
+  it "doesn't leak to the facts hash" do
     expect(subject).to contain_notify('stringfact').with(message: '')
   end
 end

--- a/spec/classes/relationships__type_with_auto_spec.rb
+++ b/spec/classes/relationships__type_with_auto_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'relationships::type_with_auto', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.0.0') >= 0 do
+describe 'relationships::type_with_auto' do
   it { is_expected.to compile.with_all_deps }
 
   it do

--- a/spec/classes/server_facts_spec.rb
+++ b/spec/classes/server_facts_spec.rb
@@ -2,24 +2,18 @@
 
 require 'spec_helper'
 
-describe 'server_facts', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
-  context 'with server_facts' do
-    before do
-      RSpec.configuration.trusted_server_facts = true
-    end
-
-    let(:facts) do
-      {
-        ipaddress: '192.168.1.10'
-      }
-    end
-    let(:node) { 'test123.test.com' }
-
-    it { is_expected.to contain_class('server_facts') }
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_notify('servername-test123.test.com') }
-    it { is_expected.to contain_notify('serverip-192.168.1.10') }
-    it { is_expected.to contain_notify("serverversion-#{Puppet.version}") }
-    it { is_expected.to contain_notify('environment-rp_env') }
+describe 'server_facts' do
+  let(:facts) do
+    {
+      ipaddress: '192.168.1.10'
+    }
   end
+  let(:node) { 'test123.test.com' }
+
+  it { is_expected.to contain_class('server_facts') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_notify('servername-test123.test.com') }
+  it { is_expected.to contain_notify('serverip-192.168.1.10') }
+  it { is_expected.to contain_notify("serverversion-#{Puppet.version}") }
+  it { is_expected.to contain_notify('environment-rp_env') }
 end

--- a/spec/classes/test_api_spec.rb
+++ b/spec/classes/test_api_spec.rb
@@ -26,13 +26,9 @@ describe 'test::bare_class' do
       expect(RSpec::Puppet::Coverage.filters).to include('Class[Test::Bare_class]')
     end
 
-    # file and line information was only added to resources created with
-    # ensure_resource() in 4.6.0 (PUP-6530).
-    if Puppet::Util::Package.versioncmp(Puppet.version, '4.6.0') >= 0
-      it 'does not include resources from other modules created with create_resources()' do
-        expect(RSpec::Puppet::Coverage.instance.results[:resources]).not_to include('Notify[create_resources notify]')
-        expect(subject).to contain_notify('create_resources notify')
-      end
+    it 'does not include resources from other modules created with create_resources()' do
+      expect(RSpec::Puppet::Coverage.instance.results[:resources]).not_to include('Notify[create_resources notify]')
+      expect(subject).to contain_notify('create_resources notify')
     end
   end
 end

--- a/spec/classes/test_basic_spec.rb
+++ b/spec/classes/test_basic_spec.rb
@@ -20,7 +20,7 @@ describe 'test::basic' do
     it { is_expected.to contain_notify('test123.test.com') }
     it { is_expected.not_to contain_notify('notthis.test.com') }
 
-    context 'existing networking facts should not be clobbered', if: Puppet.version.to_f >= 4.0 do
+    context 'existing networking facts should not be clobbered' do
       let(:pre_condition) { 'notify { [$facts["networking"]["primary"], $facts["networking"]["hostname"]]: }' }
 
       it { is_expected.to contain_notify('eth0') }

--- a/spec/classes/test_registry_spec.rb
+++ b/spec/classes/test_registry_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'test::registry', if: Puppet.version.to_f >= 4.0 do
+describe 'test::registry' do
   let(:facts) { { os: { name: 'windows' } } }
 
   it { is_expected.to compile.with_all_deps }

--- a/spec/classes/test_sensitive_spec.rb
+++ b/spec/classes/test_sensitive_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'test::sensitive', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.6.0') >= 0 do
+describe 'test::sensitive' do
   it { is_expected.to contain_class('test::sensitive::user').with_password(sensitive('myPassword')) }
   it { is_expected.to contain_class('test::sensitive::user').with_password(sensitive(/Pass/)) }
 end

--- a/spec/classes/test_windows_spec.rb
+++ b/spec/classes/test_windows_spec.rb
@@ -5,10 +5,6 @@ require 'spec_helper'
 describe 'test::windows' do
   let(:facts) { { operatingsystem: 'windows' } }
 
-  let(:symlink_path) do
-    RUBY_VERSION == '1.8.7' ? 'C:\\\\something.txt' : 'C:\\something.txt'
-  end
-
   it { is_expected.to compile.with_all_deps }
-  it { is_expected.to contain_file(symlink_path) }
+  it { is_expected.to contain_file('C:\\something.txt') }
 end

--- a/spec/classes/trusted_external_data_spec.rb
+++ b/spec/classes/trusted_external_data_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'trusted_external_data', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.14.0') >= 0 do
+describe 'trusted_external_data' do
   context 'no trusted external data' do
     it { is_expected.to contain_class('trusted_external_data') }
     it { is_expected.to compile.with_all_deps }

--- a/spec/classes/trusted_facts_spec.rb
+++ b/spec/classes/trusted_facts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'trusted_facts', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
+describe 'trusted_facts' do
   context 'FQDN as certname' do
     let(:node) { 'trusted.example.com' }
 

--- a/spec/classes/type_mismatch_spec.rb
+++ b/spec/classes/type_mismatch_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'type_mismatch', if: Puppet.version.to_f >= 4.0 do
+describe 'type_mismatch' do
   it { is_expected.to compile.with_all_deps }
 
   it do

--- a/spec/classes/undef_spec.rb
+++ b/spec/classes/undef_spec.rb
@@ -47,7 +47,7 @@ describe 'undef_test' do
     end
   end
 
-  context 'with required_attribute => :undef', unless: Puppet.version =~ /^2/ do
+  context 'with required_attribute => :undef' do
     context 'and defaults_to_undef unspecified' do
       let(:params) { { required_attribute: :undef } }
 

--- a/spec/defines/undef_def_spec.rb
+++ b/spec/defines/undef_def_spec.rb
@@ -27,7 +27,7 @@ describe 'undef_test::def' do
     end
   end
 
-  context 'with required_attribute => :undef', unless: Puppet.version =~ /^2/ do
+  context 'with required_attribute => :undef' do
     context 'and defaults_to_undef unspecified' do
       let(:params) { { required_attribute: :undef } }
 

--- a/spec/functions/facts_lookup_spec.rb
+++ b/spec/functions/facts_lookup_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rspec-puppet'
 
-describe 'structured_facts::lookup', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
+describe 'structured_facts::lookup' do
   context 'with one set of values' do
     let(:facts) { { 'os' => { 'family' => 'RedHat' } } }
 

--- a/spec/functions/lambda_function_spec.rb
+++ b/spec/functions/lambda_function_spec.rb
@@ -2,6 +2,6 @@
 
 require 'spec_helper'
 
-describe 'map', if: Puppet.version.to_i >= 4 do
+describe 'map' do
   it { is_expected.to run.with_params([1, 2]).with_lambda { |x| "test-#{x}" }.and_return(%w[test-1 test-2]) }
 end

--- a/spec/functions/nil_function_spec.rb
+++ b/spec/functions/nil_function_spec.rb
@@ -3,16 +3,6 @@
 require 'spec_helper'
 
 describe 'nil_function' do
-  let(:version) do
-    if (Puppet[:parser] == 'future') || (Puppet.version.to_f >= 4)
-      'new version'
-    else
-      'old version'
-    end
-  end
-
   it { is_expected.to run.with_params(false).and_return(nil) }
-  it { is_expected.to run.with_params(true).and_raise_error(Puppet::ParseError, /Forced Failure/) }
-
-  it { is_expected.to run.with_params(true).and_raise_error(Puppet::ParseError, /Forced Failure - #{version}/) }
+  it { is_expected.to run.with_params(true).and_raise_error(Puppet::ParseError, /Forced Failure - new version/) }
 end

--- a/spec/functions/split_spec.rb
+++ b/spec/functions/split_spec.rb
@@ -6,19 +6,8 @@ describe 'split' do
   it { is_expected.to run.with_params('aoeu', 'o').and_return(%w[a eu]) }
   it { is_expected.not_to run.with_params('foo').and_raise_error(Puppet::DevError) }
 
-  expected_error = if Puppet::Util::Package.versioncmp(Puppet.version, '3.1.0') >= 0
-                     ArgumentError
-                   else
-                     Puppet::ParseError
-                   end
-
-  expected_error_message = if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0
-                             /expects \d+ arguments/
-                           elsif Puppet::Util::Package.versioncmp(Puppet.version, '4.0.0') >= 0
-                             /mis-matched arguments/
-                           else
-                             /number of arguments/
-                           end
+  expected_error = ArgumentError
+  expected_error_message = /expects \d+ arguments/
 
   it { is_expected.to run.with_params('foo').and_raise_error(expected_error) }
 

--- a/spec/functions/test_function_spec.rb
+++ b/spec/functions/test_function_spec.rb
@@ -2,12 +2,12 @@
 
 require 'spec_helper'
 
-describe 'test_function', if: Puppet.version.to_f >= 4.0 do
+describe 'test_function' do
   # Verify that we can load functions from modules
   it { is_expected.to run.with_params('foo').and_return(/value is foo/) }
 end
 
-describe 'frozen_function', if: Puppet.version.to_f >= 4.0 do
+describe 'frozen_function' do
   it { is_expected.to run.with_params('foo').and_return(true) }
   it { is_expected.to run.with_params(String).and_return(false) }
   it { is_expected.to run.with_params(true).and_return(true) }

--- a/spec/functions/test_hiera_function_spec.rb
+++ b/spec/functions/test_hiera_function_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'test::hiera_function', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
+describe 'test::hiera_function' do
   context 'with :hiera_config set' do
     let(:hiera_config) { 'spec/fixtures/hiera.yaml' }
 

--- a/spec/functions/trusted_facts_lookup_spec.rb
+++ b/spec/functions/trusted_facts_lookup_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'trusted_facts::lookup', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
+describe 'trusted_facts::lookup' do
   let(:node) { 'trusted.example.com' }
 
   context 'without trusted fact extensions' do

--- a/spec/hosts/environment_spec.rb
+++ b/spec/hosts/environment_spec.rb
@@ -7,9 +7,7 @@ describe 'facts.acme.com' do
     it { is_expected.to contain_file('environment').with_path('rp_env') }
   end
 
-  # Broken on ~> 3.8.5 since PUP-5522
-  context 'when specifying an explicit environment',
-          unless: (Puppet.version >= '3.8.5' && Puppet.version.to_i < 4) do
+  context 'when specifying an explicit environment' do
     let(:environment) { 'test_env' }
 
     it { is_expected.to contain_file('environment').with_path('test_env') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,23 +14,15 @@ end
 
 require 'rspec-puppet'
 
-# rspec 2.x doesn't have RSpec::Support, so fall back to File::ALT_SEPARATOR to
-# detect if running on windows
+# TODO: drop?
 def windows?
   return @windowsp unless @windowsp.nil?
 
-  @windowsp = defined?(RSpec::Support) ? RSpec::Support::OS.windows? : !!File::ALT_SEPARATOR
+  @windowsp = RSpec::Support::OS.windows?
 end
 
 def sensitive?
   defined?(Puppet::Pops::Types::PSensitiveType)
-end
-
-module Helpers
-  def rspec2?
-    RSpec::Version::STRING < '3'
-  end
-  module_function :rspec2?
 end
 
 RSpec.configure do |c|
@@ -43,7 +35,4 @@ RSpec.configure do |c|
   c.after(:suite) do
     RSpec::Puppet::Coverage.report!(0)
   end
-
-  c.include Helpers
-  c.extend Helpers
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,16 +21,9 @@ def windows?
   @windowsp = RSpec::Support::OS.windows?
 end
 
-def sensitive?
-  defined?(Puppet::Pops::Types::PSensitiveType)
-end
-
 RSpec.configure do |c|
   c.module_path     = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'modules')
-  c.manifest_dir    = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'manifests')
-  c.manifest        = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'manifests', 'site.pp')
   c.environmentpath = File.join(Dir.pwd, 'spec')
-  c.parser          = ENV['FUTURE_PARSER'] == 'yes' ? 'future' : 'current'
 
   c.after(:suite) do
     RSpec::Puppet::Coverage.report!(0)

--- a/spec/spec_helper_unit.rb
+++ b/spec/spec_helper_unit.rb
@@ -13,37 +13,3 @@ if ENV['COVERAGE']
 end
 
 require 'rspec-puppet'
-
-module Helpers
-  def rspec2?
-    RSpec::Version::STRING < '3'
-  end
-  module_function :rspec2?
-
-  def test_double(type, *args)
-    if rspec2?
-      double(type.to_s, *args)
-    else
-      instance_double(type, *args)
-    end
-  end
-end
-
-RSpec.configure do |c|
-  c.include Helpers
-  c.extend Helpers
-
-  if Helpers.rspec2?
-    RSpec::Matchers.define :be_truthy do
-      match do |actual|
-        !actual.nil? == true
-      end
-    end
-
-    RSpec::Matchers.define :be_falsey do
-      match do |actual|
-        !actual.nil? == false
-      end
-    end
-  end
-end

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -36,18 +36,10 @@ describe RSpec::Puppet::Support do
   end
 
   describe '#sensitive' do
-    context 'when using a version of Puppet that supports the Sensitive type', if: sensitive? do
-      it 'returns a new Sensitive with the given contents' do
-        sens = subject.sensitive('test content')
-        expect(sens).to be_sensitive
-        expect(sens.unwrap).to eq 'test content'
-      end
-    end
-
-    context 'when using a version of Puppet that does not support Sensitive', unless: sensitive? do
-      it 'raises an error' do
-        expect { subject.sensitive('test content') }.to raise_error
-      end
+    it 'returns a new Sensitive with the given contents' do
+      sens = subject.sensitive('test content')
+      expect(sens).to be_sensitive
+      expect(sens.unwrap).to eq 'test content'
     end
   end
 
@@ -141,10 +133,6 @@ describe RSpec::Puppet::Support do
         end
 
         def site_pp_str
-          ''
-        end
-
-        def import_str
           ''
         end
       end

--- a/spec/type_aliases/onlyarray_spec.rb
+++ b/spec/type_aliases/onlyarray_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'Aliases::OnlyArray', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0 do
+describe 'Aliases::OnlyArray' do
   it { is_expected.not_to allow_value(nil, 'string') }
   it { is_expected.to allow_value(%w[a b]) }
 end

--- a/spec/type_aliases/onlyhash_spec.rb
+++ b/spec/type_aliases/onlyhash_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'Aliases::OnlyHash', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0 do
+describe 'Aliases::OnlyHash' do
   it { is_expected.not_to allow_value(nil, 'string') }
   it { is_expected.to allow_value({ 'a' => 'b' }) }
   it { is_expected.to allow_value({ 'a' => { 'b' => 'c' } }) }

--- a/spec/type_aliases/shape_spec.rb
+++ b/spec/type_aliases/shape_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'Aliases::Shape', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0 do
+describe 'Aliases::Shape' do
   it { is_expected.to allow_value('square') }
   it { is_expected.to allow_value('circle') }
   it { is_expected.not_to allow_value('triangle') }

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -24,11 +24,28 @@ describe RSpec::Puppet::Adapters::Base do
 
     null_path = windows? ? 'c:/nul/' : '/dev/null'
 
-    %i[vardir confdir].each do |setting|
+    %i[vardir codedir rundir logdir hiera_config confdir].each do |setting|
       it "sets #{setting} to #{null_path}" do
         expect(Puppet[setting]).to eq(File.expand_path(null_path))
       end
     end
+  end
+
+  it 'sets Puppet[:strict_variables] to false by default' do
+    subject.setup_puppet(test_context)
+    expect(Puppet[:strict_variables]).to be(false)
+  end
+
+  it 'reads the :strict_variables setting' do
+    allow(test_context).to receive(:strict_variables).and_return(true)
+    subject.setup_puppet(test_context)
+    expect(Puppet[:strict_variables]).to be(true)
+  end
+
+  it 'overrides the environmentpath set by Puppet::Test::TestHelper' do
+    allow(test_context).to receive(:environmentpath).and_return('/path/to/my/environments')
+    subject.setup_puppet(test_context)
+    expect(Puppet[:environmentpath]).to match(%r{(C:)?/path/to/my/environments})
   end
 
   describe '#set_setting' do
@@ -77,124 +94,6 @@ describe RSpec::Puppet::Adapters::Base do
       end
     end
   end
-end
-
-describe RSpec::Puppet::Adapters::Adapter35, if: (3.5...4.0).cover?(Puppet.version.to_f) do
-  let(:test_context) { double environment: 'rp_env' }
-
-  context 'when running on puppet 3.5 or later', if: (3.5...4.0).cover?(Puppet.version.to_f) do
-    it 'sets Puppet[:strict_variables] to false by default' do
-      subject.setup_puppet(test_context)
-      expect(Puppet[:strict_variables]).to be(false)
-    end
-
-    it 'reads the :strict_variables setting' do
-      allow(test_context).to receive(:strict_variables).and_return true
-      subject.setup_puppet(test_context)
-      expect(Puppet[:strict_variables]).to be(true)
-    end
-  end
-end
-
-describe RSpec::Puppet::Adapters::Adapter34, if: (3.4...4.0).cover?(Puppet.version.to_f) do
-  let(:test_context) { double environment: 'rp_env' }
-
-  context 'when running on puppet 3.4 or later', if: (3.4...4.0).cover?(Puppet.version.to_f) do
-    it 'sets Puppet[:trusted_node_data] to false by default' do
-      subject.setup_puppet(test_context)
-      expect(Puppet[:trusted_node_data]).to be(false)
-    end
-
-    it 'reads the :trusted_node_data setting' do
-      allow(test_context).to receive(:trusted_node_data).and_return(true)
-      subject.setup_puppet(test_context)
-      expect(Puppet[:trusted_node_data]).to be(true)
-    end
-  end
-end
-
-describe RSpec::Puppet::Adapters::Adapter33, if: (3.3...4.0).cover?(Puppet.version.to_f) do
-  let(:test_context) { double environment: 'rp_env' }
-
-  context 'when running on puppet ~> 3.3', if: (3.3...4.0).cover?(Puppet.version.to_f) do
-    it 'sets Puppet[:stringify_facts] to true by default' do
-      subject.setup_puppet(test_context)
-      expect(Puppet[:stringify_facts]).to be(true)
-    end
-
-    it 'reads the :stringify_facts setting' do
-      allow(test_context).to receive(:stringify_facts).and_return false
-      subject.setup_puppet(test_context)
-      expect(Puppet[:stringify_facts]).to be(false)
-    end
-
-    it 'sets Puppet[:ordering] to title-hash by default' do
-      subject.setup_puppet(test_context)
-      expect(Puppet[:ordering]).to eq('title-hash')
-    end
-
-    it 'reads the :ordering setting' do
-      allow(test_context).to receive(:ordering).and_return('manifest')
-      subject.setup_puppet(test_context)
-      expect(Puppet[:ordering]).to eq('manifest')
-    end
-  end
-end
-
-describe RSpec::Puppet::Adapters::Adapter32, if: (3.2...4.0).cover?(Puppet.version.to_f) do
-  let(:test_context) { double environment: 'rp_env' }
-
-  context 'when running on puppet ~> 3.2', if: (3.2...4.0).cover?(Puppet.version.to_f) do
-    it 'sets Puppet[:parser] to "current" by default' do
-      subject.setup_puppet(test_context)
-      expect(Puppet[:parser]).to eq('current')
-    end
-
-    it 'reads the :parser setting' do
-      allow(test_context).to receive(:parser).and_return('future')
-      subject.setup_puppet(test_context)
-      expect(Puppet[:parser]).to eq('future')
-    end
-  end
-
-  describe 'default settings' do
-    before do
-      subject.setup_puppet(context_double)
-    end
-
-    null_path = windows? ? 'c:/nul/' : '/dev/null'
-
-    %i[vardir rundir logdir hiera_config confdir].each do |setting|
-      it "sets #{setting} to #{null_path}" do
-        expect(Puppet[setting]).to eq(File.expand_path(null_path))
-      end
-    end
-  end
-end
-
-describe RSpec::Puppet::Adapters::Adapter6X, if: (6.0...6.25).cover?(Puppet.version.to_f) do
-  let(:test_context) { double environment: 'rp_env' }
-
-  describe '#setup_puppet' do
-    describe 'when managing the facter_implementation' do
-      after do
-        Object.send(:remove_const, :FacterImpl) if defined? FacterImpl
-      end
-
-      it 'warns and falls back if hash implementation is set and facter runtime is not supported' do
-        context = context_double
-        allow(RSpec.configuration).to receive(:facter_implementation).and_return('rspec')
-        expect(subject).to receive(:warn)
-          .with("Facter runtime implementations are not supported in Puppet #{Puppet.version}, continuing with facter_implementation 'facter'")
-        subject.setup_puppet(context)
-        expect(FacterImpl).to be(Facter)
-      end
-    end
-  end
-end
-
-describe RSpec::Puppet::Adapters::Adapter6X, if: Puppet::Util::Package.versioncmp(Puppet.version, '6.25.0') >= 0 do
-  let(:test_context) { double environment: 'rp_env' }
 
   describe '#setup_puppet' do
     describe 'when managing the facter_implementation' do
@@ -233,56 +132,6 @@ describe RSpec::Puppet::Adapters::Adapter6X, if: Puppet::Util::Package.versioncm
         allow(RSpec.configuration).to receive(:facter_implementation).and_return('salam')
         expect { subject.setup_puppet(context) }
           .to raise_error(RuntimeError, "Unsupported facter_implementation 'salam'")
-      end
-    end
-  end
-end
-
-describe RSpec::Puppet::Adapters::Adapter4X, if: (4.0...6.0).cover?(Puppet.version.to_f) do
-  let(:test_context) { double environment: 'rp_env' }
-
-  it 'sets Puppet[:strict_variables] to false by default' do
-    subject.setup_puppet(test_context)
-    expect(Puppet[:strict_variables]).to be(false)
-  end
-
-  it 'reads the :strict_variables setting' do
-    allow(test_context).to receive(:strict_variables).and_return(true)
-    subject.setup_puppet(test_context)
-    expect(Puppet[:strict_variables]).to be(true)
-  end
-
-  it 'overrides the environmentpath set by Puppet::Test::TestHelper' do
-    allow(test_context).to receive(:environmentpath).and_return('/path/to/my/environments')
-    subject.setup_puppet(test_context)
-    expect(Puppet[:environmentpath]).to match(%r{(C:)?/path/to/my/environments})
-  end
-
-  describe '#manifest' do
-    it 'returns the configured environment manifest when set' do
-      allow(RSpec.configuration).to receive(:manifest).and_return('/path/to/manifest')
-      subject.setup_puppet(double(environment: 'rp_puppet'))
-      expect(subject.manifest).to match(%r{(C:)?/path/to/manifest})
-    end
-
-    it 'returns nil when the configured environment manifest is not set' do
-      allow(RSpec.configuration).to receive(:manifest)
-      allow(RSpec.configuration).to receive(:environmentpath).and_return('/some/missing/path:/another/missing/path')
-      subject.setup_puppet(double(environment: 'rp_puppet'))
-      expect(subject.manifest).to be_nil
-    end
-  end
-
-  describe 'default settings' do
-    before do
-      subject.setup_puppet(context_double)
-    end
-
-    null_path = windows? ? 'c:/nul/' : '/dev/null'
-
-    %i[vardir codedir rundir logdir hiera_config confdir].each do |setting|
-      it "sets #{setting} to #{null_path}" do
-        expect(Puppet[setting]).to eq(File.expand_path(null_path))
       end
     end
   end

--- a/spec/unit/example/function_example_group_spec.rb
+++ b/spec/unit/example/function_example_group_spec.rb
@@ -2,27 +2,25 @@
 
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.0
-  describe RSpec::Puppet::FunctionExampleGroup::V4FunctionWrapper do
-    let(:name) { 'test_function' }
-    let(:func) { double('func') }
-    let(:global_scope) { double('global_scope') }
-    let(:overrides) { { global_scope: global_scope } }
+describe RSpec::Puppet::FunctionExampleGroup::V4FunctionWrapper do
+  let(:name) { 'test_function' }
+  let(:func) { double('func') }
+  let(:global_scope) { double('global_scope') }
+  let(:overrides) { { global_scope: global_scope } }
 
-    describe 'when calling with params' do
-      subject { described_class.new(name, func, overrides) }
-      it do
-        expect(func).to receive(:call).with(global_scope, 1, 2).once
-        subject.call({}, 1, 2)
-      end
+  describe 'when calling with params' do
+    subject { described_class.new(name, func, overrides) }
+    it do
+      expect(func).to receive(:call).with(global_scope, 1, 2).once
+      subject.call({}, 1, 2)
     end
+  end
 
-    describe 'when executing with params' do
-      subject { described_class.new(name, func, overrides) }
-      it do
-        expect(func).to receive(:call).with(global_scope, 1, 2).once
-        subject.execute(1, 2)
-      end
+  describe 'when executing with params' do
+    subject { described_class.new(name, func, overrides) }
+    it do
+      expect(func).to receive(:call).with(global_scope, 1, 2).once
+      subject.execute(1, 2)
     end
   end
 end

--- a/spec/unit/matchers/allow_value_spec.rb
+++ b/spec/unit/matchers/allow_value_spec.rb
@@ -3,8 +3,7 @@
 require 'spec_helper'
 require 'rspec-puppet/support'
 
-# is_expected.to not available with rspec 2.14, which is only used for puppet < 3
-describe RSpec::Puppet::TypeAliasMatchers::AllowValue, if: Puppet.version.to_f >= 3.0 do
+describe RSpec::Puppet::TypeAliasMatchers::AllowValue do
   subject { described_class.new(values) }
 
   let(:catalogue) { double('catalogue builder') }

--- a/spec/unit/matchers/compile_spec.rb
+++ b/spec/unit/matchers/compile_spec.rb
@@ -3,93 +3,188 @@
 require 'spec_helper'
 require 'rspec-puppet/support'
 
-# is_expected.to and a_string_starting_with not available with rspec 2.14, which is only used for puppet < 3
-if Puppet.version.to_f >= 3.0
-  describe RSpec::Puppet::ManifestMatchers::Compile do
-    include RSpec::Puppet::Support
-    # override RSpec::Puppet::Support's subject with the original default
-    subject { described_class.new }
+describe RSpec::Puppet::ManifestMatchers::Compile do
+  include RSpec::Puppet::Support
+  # override RSpec::Puppet::Support's subject with the original default
+  subject { described_class.new }
 
-    let(:catalogue) { -> { load_catalogue(:host) } }
-    let(:facts) { { 'operatingsystem' => 'Debian' } }
+  let(:catalogue) { -> { load_catalogue(:host) } }
+  let(:facts) { { 'operatingsystem' => 'Debian' } }
 
-    describe 'a valid manifest' do
-      let(:pre_condition) { 'file { "/tmp/resource": }' }
+  describe 'a valid manifest' do
+    let(:pre_condition) { 'file { "/tmp/resource": }' }
+
+    it('matches') { is_expected.to be_matches catalogue }
+
+    it {
+      expect(subject).to have_attributes(
+        description: 'compile into a catalogue without dependency cycles'
+      )
+    }
+
+    context 'when expecting an "example" error' do
+      before { subject.and_raise_error('example') }
+
+      it("doesn't match") { is_expected.not_to be_matches catalogue }
+
+      it {
+        expect(subject).to have_attributes(
+          description: 'fail to compile and raise the error "example"'
+        )
+      }
+
+      context 'after matching' do
+        before { subject.matches? catalogue }
+
+        it {
+          expect(subject).to have_attributes(
+            failure_message: a_string_starting_with('expected that the catalogue would fail to compile and raise the error "example"')
+          )
+        }
+      end
+    end
+
+    context 'when matching an "example" error' do
+      before { subject.and_raise_error(/example/) }
+
+      it("doesn't match") { is_expected.not_to be_matches catalogue }
+
+      it {
+        expect(subject).to have_attributes(
+          description: 'fail to compile and raise an error matching /example/'
+        )
+      }
+
+      context 'after matching' do
+        before { subject.matches? catalogue }
+
+        it {
+          expect(subject).to have_attributes(
+            failure_message: a_string_starting_with('expected that the catalogue would fail to compile and raise an error matching /example/')
+          )
+        }
+      end
+    end
+  end
+
+  describe 'a manifest with missing dependencies' do
+    let(:pre_condition) { 'file { "/tmp/resource": require => File["/tmp/missing"] }' }
+
+    it("doesn't match") { is_expected.not_to be_matches catalogue }
+
+    context 'after matching' do
+      before { subject.matches? catalogue }
+
+      it {
+        expect(subject).to have_attributes(
+          failure_message: a_string_matching(%r{\Aerror during compilation: Could not (retrieve dependency|find resource) 'File\[/tmp/missing\]'})
+        )
+      }
+    end
+  end
+
+  describe 'a manifest with syntax error' do
+    let(:pre_condition) { 'file { "/tmp/resource": ' }
+
+    it("doesn't match") { is_expected.not_to be_matches catalogue }
+
+    context 'after matching' do
+      before { subject.matches? catalogue }
+
+      it {
+        expect(subject).to have_attributes(
+          failure_message: a_string_starting_with('error during compilation: ')
+        )
+      }
+    end
+  end
+
+  describe 'a manifest with a dependency cycle' do
+    let(:pre_condition) do
+      <<-EOS
+      file { "/tmp/a": require => File["/tmp/b"] }
+      file { "/tmp/b": require => File["/tmp/a"] }
+      EOS
+    end
+
+    it("doesn't match") { is_expected.not_to be_matches catalogue }
+
+    context 'after matching' do
+      before { subject.matches? catalogue }
+
+      it {
+        expect(subject).to have_attributes(
+          failure_message: a_string_starting_with('dependency cycles found: ')
+        )
+      }
+    end
+
+    context 'when expecting an "example" error' do
+      before { subject.and_raise_error('example') }
+
+      it("doesn't match") { is_expected.not_to be_matches catalogue }
+
+      context 'after matching' do
+        before { subject.matches? catalogue }
+
+        it {
+          expect(subject).to have_attributes(
+            description: 'fail to compile and raise the error "example"',
+            failure_message: a_string_starting_with('dependency cycles found: ')
+          )
+        }
+      end
+    end
+
+    context 'when matching an "example" error' do
+      before { subject.and_raise_error(/example/) }
+
+      it("doesn't match") { is_expected.not_to be_matches catalogue }
+
+      context 'after matching' do
+        before { subject.matches? catalogue }
+
+        it {
+          expect(subject).to have_attributes(
+            description: 'fail to compile and raise an error matching /example/',
+            failure_message: a_string_starting_with('dependency cycles found: ')
+          )
+        }
+      end
+    end
+  end
+
+  describe 'a manifest with a real failure' do
+    let(:pre_condition) { 'fail("failure")' }
+
+    it("doesn't match") { is_expected.not_to be_matches catalogue }
+
+    context 'after matching' do
+      before { subject.matches? catalogue }
+
+      it {
+        expect(subject).to have_attributes(
+          description: 'compile into a catalogue without dependency cycles',
+          failure_message: a_string_starting_with('error during compilation: ')
+        )
+      }
+    end
+
+    context 'when expecting the failure' do
+      let(:expected_error) do
+        "Evaluation Error: Error while evaluating a Function Call, 'failure (line: 52, column: 1)' on node rspec::puppet::manifestmatchers::compile"
+      end
+
+      before { subject.and_raise_error(expected_error) }
 
       it('matches') { is_expected.to be_matches catalogue }
 
       it {
         expect(subject).to have_attributes(
-          description: 'compile into a catalogue without dependency cycles'
+          description: "fail to compile and raise the error \"#{expected_error}\""
         )
       }
 
-      context 'when expecting an "example" error' do
-        before { subject.and_raise_error('example') }
-
-        it("doesn't match") { is_expected.not_to be_matches catalogue }
-
-        it {
-          expect(subject).to have_attributes(
-            description: 'fail to compile and raise the error "example"'
-          )
-        }
-
-        context 'after matching' do
-          before { subject.matches? catalogue }
-
-          it {
-            expect(subject).to have_attributes(
-              failure_message: a_string_starting_with('expected that the catalogue would fail to compile and raise the error "example"')
-            )
-          }
-        end
-      end
-
-      context 'when matching an "example" error' do
-        before { subject.and_raise_error(/example/) }
-
-        it("doesn't match") { is_expected.not_to be_matches catalogue }
-
-        it {
-          expect(subject).to have_attributes(
-            description: 'fail to compile and raise an error matching /example/'
-          )
-        }
-
-        context 'after matching' do
-          before { subject.matches? catalogue }
-
-          it {
-            expect(subject).to have_attributes(
-              failure_message: a_string_starting_with('expected that the catalogue would fail to compile and raise an error matching /example/')
-            )
-          }
-        end
-      end
-    end
-
-    describe 'a manifest with missing dependencies' do
-      let(:pre_condition) { 'file { "/tmp/resource": require => File["/tmp/missing"] }' }
-
-      it("doesn't match") { is_expected.not_to be_matches catalogue }
-
-      context 'after matching' do
-        before { subject.matches? catalogue }
-
-        it {
-          expect(subject).to have_attributes(
-            failure_message: a_string_matching(%r{\Aerror during compilation: Could not (retrieve dependency|find resource) 'File\[/tmp/missing\]'})
-          )
-        }
-      end
-    end
-
-    describe 'a manifest with syntax error' do
-      let(:pre_condition) { 'file { "/tmp/resource": ' }
-
-      it("doesn't match") { is_expected.not_to be_matches catalogue }
-
       context 'after matching' do
         before { subject.matches? catalogue }
 
@@ -101,132 +196,25 @@ if Puppet.version.to_f >= 3.0
       end
     end
 
-    describe 'a manifest with a dependency cycle' do
-      let(:pre_condition) do
-        <<-EOS
-        file { "/tmp/a": require => File["/tmp/b"] }
-        file { "/tmp/b": require => File["/tmp/a"] }
-        EOS
-      end
+    context 'when matching the failure' do
+      before { subject.and_raise_error(/failure/) }
 
-      it("doesn't match") { is_expected.not_to be_matches catalogue }
+      it('matches') { is_expected.to be_matches catalogue }
 
-      context 'after matching' do
-        before { subject.matches? catalogue }
-
-        it {
-          expect(subject).to have_attributes(
-            failure_message: a_string_starting_with('dependency cycles found: ')
-          )
-        }
-      end
-
-      context 'when expecting an "example" error' do
-        before { subject.and_raise_error('example') }
-
-        it("doesn't match") { is_expected.not_to be_matches catalogue }
-
-        context 'after matching' do
-          before { subject.matches? catalogue }
-
-          it {
-            expect(subject).to have_attributes(
-              description: 'fail to compile and raise the error "example"',
-              failure_message: a_string_starting_with('dependency cycles found: ')
-            )
-          }
-        end
-      end
-
-      context 'when matching an "example" error' do
-        before { subject.and_raise_error(/example/) }
-
-        it("doesn't match") { is_expected.not_to be_matches catalogue }
-
-        context 'after matching' do
-          before { subject.matches? catalogue }
-
-          it {
-            expect(subject).to have_attributes(
-              description: 'fail to compile and raise an error matching /example/',
-              failure_message: a_string_starting_with('dependency cycles found: ')
-            )
-          }
-        end
-      end
-    end
-
-    describe 'a manifest with a real failure' do
-      let(:pre_condition) { 'fail("failure")' }
-
-      it("doesn't match") { is_expected.not_to be_matches catalogue }
+      it {
+        expect(subject).to have_attributes(
+          description: 'fail to compile and raise an error matching /failure/'
+        )
+      }
 
       context 'after matching' do
         before { subject.matches? catalogue }
 
         it {
           expect(subject).to have_attributes(
-            description: 'compile into a catalogue without dependency cycles',
             failure_message: a_string_starting_with('error during compilation: ')
           )
         }
-      end
-
-      context 'when expecting the failure' do
-        let(:expected_error) do
-          "Evaluation Error: Error while evaluating a Function Call, #{error_detail} on node rspec::puppet::manifestmatchers::compile"
-        end
-
-        before { subject.and_raise_error(expected_error) }
-
-        if Puppet::Util::Package.versioncmp(Puppet.version, '5.3.4') >= 0
-          let(:error_detail) { 'failure (line: 52, column: 1)' }
-        else
-          let(:error_detail) { 'failure at line 52:1' }
-        end
-
-        if Puppet.version.to_f >= 4.0
-          # the error message above is puppet4 specific
-          it('matches') { is_expected.to be_matches catalogue }
-        end
-
-        it {
-          expect(subject).to have_attributes(
-            description: "fail to compile and raise the error \"#{expected_error}\""
-          )
-        }
-
-        context 'after matching' do
-          before { subject.matches? catalogue }
-
-          it {
-            expect(subject).to have_attributes(
-              failure_message: a_string_starting_with('error during compilation: ')
-            )
-          }
-        end
-      end
-
-      context 'when matching the failure' do
-        before { subject.and_raise_error(/failure/) }
-
-        it('matches') { is_expected.to be_matches catalogue }
-
-        it {
-          expect(subject).to have_attributes(
-            description: 'fail to compile and raise an error matching /failure/'
-          )
-        }
-
-        context 'after matching' do
-          before { subject.matches? catalogue }
-
-          it {
-            expect(subject).to have_attributes(
-              failure_message: a_string_starting_with('error during compilation: ')
-            )
-          }
-        end
       end
     end
   end

--- a/spec/unit/matchers/count_generic_spec.rb
+++ b/spec/unit/matchers/count_generic_spec.rb
@@ -6,12 +6,12 @@ describe RSpec::Puppet::ManifestMatchers::CountGeneric do
   subject(:matcher) { described_class.new(type, expected, method) }
 
   let(:actual) do
-    -> { test_double(Puppet::Resource::Catalog, resources: resource_objects) }
+    -> { instance_double(Puppet::Resource::Catalog, resources: resource_objects) }
   end
 
   let(:resource_objects) do
     resources.map do |type, title|
-      test_double(Puppet::Resource, ref: "#{type}[#{title}]", type: type)
+      instance_double(Puppet::Resource, ref: "#{type}[#{title}]", type: type)
     end
   end
 

--- a/spec/unit/matchers/include_class_spec.rb
+++ b/spec/unit/matchers/include_class_spec.rb
@@ -6,7 +6,7 @@ describe 'RSpec::Puppet::ManifestMatchers.include_class' do
   subject(:matcher) { Class.new { extend RSpec::Puppet::ManifestMatchers }.include_class(expected) }
 
   let(:actual) do
-    -> { test_double(Puppet::Resource::Catalog, classes: included_classes) }
+    -> { instance_double(Puppet::Resource::Catalog, classes: included_classes) }
   end
 
   let(:expected) { 'test_class' }
@@ -44,31 +44,14 @@ describe 'RSpec::Puppet::ManifestMatchers.include_class' do
     end
   end
 
-  describe '#failure_message_for_should', if: rspec2? do
-    it 'provides a description and the expected class' do
-      matcher.matches?(actual)
-      expect(matcher.failure_message_for_should).to eq("expected that the catalogue would include Class[#{expected}]")
-    end
-  end
-
-  describe '#failure_message', unless: rspec2? do
+  describe '#failure_message' do
     it 'provides a description and the expected class' do
       matcher.matches?(actual)
       expect(matcher.failure_message).to eq("expected that the catalogue would include Class[#{expected}]")
     end
   end
 
-  describe '#failure_message_for_should_not', if: rspec2? do
-    let(:included_classes) { [expected] }
-
-    it 'provides a description and the expected class' do
-      pending 'not implemented'
-      matcher.matches?(actual)
-      expect(matcher.failure_message_when_negated).to eq("expected that the catalogue would not include Class[#{expected}]")
-    end
-  end
-
-  describe '#failure_message_when_negated', unless: rspec2? do
+  describe '#failure_message_when_negated' do
     let(:included_classes) { [expected] }
 
     it 'provides a description and the expected class' do

--- a/spec/unit/matchers/run_spec.rb
+++ b/spec/unit/matchers/run_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper_unit'
 describe RSpec::Puppet::FunctionMatchers::Run do
   subject(:matcher) { described_class.new }
 
-  let(:wrapper) { test_double(RSpec::Puppet::FunctionExampleGroup::V4FunctionWrapper) }
+  let(:wrapper) { instance_double(RSpec::Puppet::FunctionExampleGroup::V4FunctionWrapper) }
 
   describe '#matches?' do
     context 'when the function takes no arguments and has no expected return value' do

--- a/spec/unit/monkey_patches_spec.rb
+++ b/spec/unit/monkey_patches_spec.rb
@@ -133,19 +133,11 @@ end
 
 describe 'Puppet::Module#match_manifests' do
   subject do
-    if Puppet::Module.instance_method(:initialize).arity == -2
-      Puppet::Module.new(
-        'escape',
-        path: File.join(RSpec.configuration.module_path, 'escape'),
-        environment: 'production'
-      )
-    else
-      Puppet::Module.new(
-        'escape',
-        File.join(RSpec.configuration.module_path, 'escape'),
-        'production'
-      )
-    end
+    Puppet::Module.new(
+      'escape',
+      File.join(RSpec.configuration.module_path, 'escape'),
+      'production'
+    )
   end
 
   it 'returns init.pp for top level class' do

--- a/spec/unit/sensitive_spec.rb
+++ b/spec/unit/sensitive_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'rspec-puppet/sensitive'
 
-describe RSpec::Puppet::Sensitive, if: sensitive? do
+describe RSpec::Puppet::Sensitive do
   subject(:sensitive) { described_class.new contents }
 
   let(:contents) { double :contents }
@@ -26,7 +26,7 @@ describe RSpec::Puppet::Sensitive, if: sensitive? do
     end
   end
 
-  describe '#==', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.6.0') >= 0 do
+  describe '#==' do
     it 'compares equal to Puppet sensitive type' do
       expect(sensitive).to eq Puppet::Pops::Types::PSensitiveType::Sensitive.new contents
     end


### PR DESCRIPTION
This avoids the need to have any version specific code and it's the only thing that's testing in CI.

Right now still a draft since I'm not quite sure how it should turn out. Includes https://github.com/puppetlabs/rspec-puppet/pull/67