### PR TITLE
(CAT-1235) - Rename to puppetlabs-rspec-puppet

### DIFF
--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary = 'RSpec tests for your Puppet manifests'
   s.description = <<-DESC
     RSpec tests for your Puppet manifests.
-    Note: Support for this gem has been moved under a new namespace and as such any future updates from
-    the Puppet team will be released as `puppetlabs-rspec-puppet`.
   DESC
   s.license = 'MIT'
 
@@ -23,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rspec', '~> 3.0'
 
   s.authors = ['Tim Sharpe', 'Puppet, Inc.', 'Community Contributors']
-  s.email = ['tim@sharpe.id.au', 'modules-team@puppet.com']
+  s.email = ['modules-team@puppet.com']
   s.metadata['rubygems_mfa_required'] = 'true'
 
   s.required_ruby_version = Gem::Requirement.new('>= 2.7.0')

--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rspec-puppet/version'
 
 Gem::Specification.new do |s|
-  s.name = 'rspec-puppet'
+  s.name = 'puppetlabs-rspec-puppet'
   s.version = RSpecPuppet::VERSION
   s.homepage = 'https://github.com/puppetlabs/rspec-puppet/'
   s.summary = 'RSpec tests for your Puppet manifests'


### PR DESCRIPTION
## Summary
Updates the naming of the gem on rubygems.org from `rspec-puppet` to `puppetlabs-rspec-puppet`
## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
