### PR TITLE
(maint) - remove irrelevant readme sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,6 @@ Hash | `{}`    | any
 A hash of default trusted facts that should be used for all the tests
 (available in the manifests as the `$trusted` hash).
 
-#### trusted\_node\_data
-Type    | Default | Puppet Version(s)
-------- | ------- | -----------------
-Boolean | `false` | any
-
-Configures rspec-puppet to use the `$trusted` hash when compiling the
-catalogues.
-
 #### confdir
 Type   | Default         | Puppet Version(s)
 ------ | --------------- | ------------------

--- a/README.md
+++ b/README.md
@@ -101,14 +101,6 @@ Boolean | `false` | any
 Configures rspec-puppet to use the `$trusted` hash when compiling the
 catalogues.
 
-#### trusted\_server\_facts
-Type    | Default | Puppet Version(s)
-------- | ------- | -----------------
-Boolean | `false` | any
-
-Configures rspec-puppet to use the `$server_facts` hash when compiling the
-catalogues.
-
 #### confdir
 Type   | Default         | Puppet Version(s)
 ------ | --------------- | ------------------


### PR DESCRIPTION
## Summary
trusted_server_facts config setting was removed in Puppet 6.x and from rspec-puppet in https://github.com/puppetlabs/rspec-puppet/pull/73.


trusted_node_data was also removed in puppet 4.x+ and from rspec-puppet in https://github.com/puppetlabs/rspec-puppet/pull/73.

This removes the now irrelevant readme sections.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
