### PR TITLE
(maint) Fix rubocop lint warnings

### DIFF
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -100,7 +100,7 @@ module RSpec::Puppet
         return func if func.func
 
         if Puppet::Parser::Functions.function(function_name)
-          V3FunctionWrapper.new(function_name, scope.method("function_#{function_name}".intern))
+          V3FunctionWrapper.new(function_name, scope.method(:"function_#{function_name}"))
         end
       end
     end

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -303,7 +303,7 @@ module RSpec::Puppet
 
         # Add auto* (autorequire etc) if any
         if %i[before notify require subscribe].include?(type)
-          func = "eachauto#{type}".to_sym
+          func = :"eachauto#{type}"
           if resource.resource_type.respond_to?(func)
             resource.resource_type.send(func) do |t, b|
               Array(resource.to_ral.instance_eval(&b)).each do |dep|

--- a/lib/rspec-puppet/matchers/type_matchers.rb
+++ b/lib/rspec-puppet/matchers/type_matchers.rb
@@ -123,7 +123,7 @@ module RSpec::Puppet
           param = param.to_sym
           if attr_type == :feature
             baddies.push(param) unless type.provider_feature(param)
-          elsif !type.send("valid#{attr_type}?".to_sym, param)
+          elsif !type.send(:"valid#{attr_type}?", param)
             baddies.push(param)
           end
         end

--- a/spec/types/valid_provider_spec.rb
+++ b/spec/types/valid_provider_spec.rb
@@ -19,7 +19,7 @@ describe 'fake' do
         [v[:baddies], v[:baddies].first].each do |baddies|
           it "fails for #{baddies.size} baddies" do
             expect do
-              expect(subject).to be_valid_type.send("with_#{k}".to_sym, baddies)
+              expect(subject).to be_valid_type.send(:"with_#{k}", baddies)
             end.to raise_error(
               RSpec::Expectations::ExpectationNotMetError,
               /Invalid #{k}: #{Array(baddies).join(',')}/
@@ -29,7 +29,7 @@ describe 'fake' do
 
         [v[:goodies], v[:goodies].first].each do |goodies|
           it "passes with #{goodies.size} goodies" do
-            expect(subject).to be_valid_type.send("with_#{k}".to_sym, goodies)
+            expect(subject).to be_valid_type.send(:"with_#{k}", goodies)
           end
         end
       end


### PR DESCRIPTION
## Summary
Fix rubocop string-to-symbol conversion [nightly CI failures](https://github.com/puppetlabs/rspec-puppet/actions/runs/7080260406/job/19267896863):


```bash
➜  rspec-puppet git:(maint_fix_rubocop_warnings) bundle exec rubocop --format github

::error file=lib/rspec-puppet/example/function_example_group.rb,line=103,col=61::Lint/SymbolConversion: Unnecessary symbol conversion; use `:"function_#{function_name}"` instead.
::error file=lib/rspec-puppet/matchers/create_generic.rb,line=306,col=18::Lint/SymbolConversion: Unnecessary symbol conversion; use `:"eachauto#{type}"` instead.
::error file=lib/rspec-puppet/matchers/type_matchers.rb,line=126,col=28::Lint/SymbolConversion: Unnecessary symbol conversion; use `:"valid#{attr_type}?"` instead.
::error file=spec/types/valid_provider_spec.rb,line=22,col=53::Lint/SymbolConversion: Unnecessary symbol conversion; use `:"with_#{k}"` instead.
::error file=spec/types/valid_provider_spec.rb,line=32,col=51::Lint/SymbolConversion: Unnecessary symbol conversion; use `:"with_#{k}"` instead.
➜  rspec-puppet git:(maint_fix_rubocop_warnings) 
```

For example:

```diff
?➜  rspec-puppet git:(maint_fix_rubocop_warnings) git diff main..HEAD
diff --git a/lib/rspec-puppet/example/function_example_group.rb b/lib/rspec-puppet/example/function_example_group.rb
index df34fb0..6836129 100644
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -100,7 +100,7 @@ module RSpec::Puppet
         return func if func.func
 
         if Puppet::Parser::Functions.function(function_name)
-          V3FunctionWrapper.new(function_name, scope.method("function_#{function_name}".intern))
+          V3FunctionWrapper.new(function_name, scope.method(:"function_#{function_name}"))
         end
       end
     end
```

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
