### PR TITLE
Revert "(maint) - fix rubocop" - Leading argument with delegation syntax not supported with ruby 2.7.0

### DIFF
--- a/lib/rspec-puppet/matchers/dynamic_matchers.rb
+++ b/lib/rspec-puppet/matchers/dynamic_matchers.rb
@@ -26,8 +26,8 @@ module RSpec::Puppet
   end
 
   module TypeMatchers
-    def method_missing(method, ...)
-      return RSpec::Puppet::TypeMatchers::CreateGeneric.new(method, ...) if method == :be_valid_type
+    def method_missing(method, *args, &block)
+      return RSpec::Puppet::TypeMatchers::CreateGeneric.new(method, *args, &block) if method == :be_valid_type
 
       super
     end


### PR DESCRIPTION
This reverts commit a16dc28e02c6fcdb786b719dd12ec5e947bffc14.

## Summary
Fixes https://github.com/puppetlabs/rspec-puppet/issues/87

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
