### PR TITLE
(maint) - Remove mfa enabled in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,5 @@ Style/ClassAndModuleChildren:
 # As the new cops are already present, e.g., Rspec/SpecFilePathPathFormat, then disabling this in preparation
 RSpec/FilePath:
   Enabled: false
+Gemspec/RequireMFA:
+  Enabled: false

--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
 
   s.authors = ['Tim Sharpe', 'Puppet, Inc.', 'Community Contributors']
   s.email = ['tim@sharpe.id.au', 'modules-team@puppet.com']
-  s.metadata['rubygems_mfa_required'] = 'true'
 
   s.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 end


### PR DESCRIPTION
Enabling MFA in the gemspec causes issues with our automated CI release job. We already pass keys to authenticate, so no need to provide another authenitcation token.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
