### PR TITLE
(MAINT) Disable new Rspec/RemoveConst cop

### DIFF
--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -102,7 +102,7 @@ describe RSpec::Puppet::Adapters::Base do
   describe '#setup_puppet' do
     describe 'when managing the facter_implementation' do
       after do
-        Object.send(:remove_const, :FacterImpl) if defined? FacterImpl
+        Object.send(:remove_const, :FacterImpl) if defined? FacterImpl # rubocop:disable RSpec/RemoveConst
       end
 
       it 'uses facter as default implementation' do


### PR DESCRIPTION
Following the recent introduction of a new cop in Rubocop, Rspec/RemoveConst, our CI has started failing. It seems like this rule is being enforced as a good practice to avoid buggy debug information but no real alternative is being offered.

This commit disables the cop to allow the CI to continue working. Here are the discussions that led to the creation of the rule: 
https://github.com/rubocop/rubocop-rspec/issues/1748 
https://github.com/rubocop/rubocop-rspec/pull/1749