### PR TITLE
(bug) - Add license file to built gem

### DIFF
--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.executables = ['rspec-puppet-init']
 
-  s.files = Dir['CHANGELOG.md', 'LICENSE.md', 'README.md', 'lib/**/*', 'bin/**/*']
+  s.files = Dir['CHANGELOG.md', 'LICENSE', 'README.md', 'lib/**/*', 'bin/**/*']
 
   s.add_dependency 'rspec', '~> 3.0'
 


### PR DESCRIPTION
## Summary
Prior to this PR, the LICENSE file was not shipped with our built gem.

This PR corrects the filename in the gemspec, so that the LICENSE file is now packaged with the gem once built.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Fixes https://github.com/puppetlabs/rspec-puppet/issues/107

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
