### PR TITLE
Set correct source directory for jekyll gh-pages action

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./docs/
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary

The default jekyll gh-pages action "sources" its documentation from the root "/" of the repository; however, the `rspec-puppet` has its documentation root beneath "/docs/".  In other words, the "/docs/" directory contains more advanced jekyll configuration like a "/docs/_config.yml" and a "/docs/_includes/" directory.  This PR fixes the gh-pages deployment.

See <https://puppetlabs.github.io/rspec-puppet/> for latest documentation

## Related Issues (if any)

Mention any related issues or pull requests.

## Checklist
- [x] Manually verified.  See <https://puppetlabs.github.io/rspec-puppet/>
