### PR TITLE
server_facts: Switch from legacy to structured facts

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -301,8 +301,7 @@ module RSpec::Puppet
       server_facts['serverversion'] = Puppet.version.to_s
 
       # And then add the server name and IP
-      { 'servername' => 'fqdn',
-        'serverip' => 'ipaddress' }.each do |var, fact|
+      { 'servername' => 'networking.fqdn', 'serverip' => 'networking.ip' }.each do |var, fact|
         if (value = Puppet.runtime[:facter].value(fact))
           server_facts[var] = value
         else
@@ -311,8 +310,8 @@ module RSpec::Puppet
       end
 
       if server_facts['servername'].nil?
-        host = Puppet.runtime[:facter].value(:hostname)
-        server_facts['servername'] = if (domain = Puppet.runtime[:facter].value(:domain))
+        host = Puppet.runtime[:facter].value('networking.hostname')
+        server_facts['servername'] = if (domain = Puppet.runtime[:facter].value('networking.domain'))
                                        [host, domain].join('.')
                                      else
                                        host

--- a/spec/classes/server_facts_spec.rb
+++ b/spec/classes/server_facts_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'server_facts' do
   let(:facts) do
     {
-      ipaddress: '192.168.1.10'
+      'networking' => { 'ip' => '192.168.1.10' }
     }
   end
   let(:node) { 'test123.test.com' }


### PR DESCRIPTION
structured facts are around since some years and the legacy facts are deprecated. The current releases causes a lot of `Could not retrieve fact ipaddress` warnings during CI run.