### PR TITLE
(CAT-2281) Remove puppet 7 infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - "2.7"
           - "3.2"
         include:
-          - ruby-version: '2.7'
-            puppet_gem_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_gem_version: '~> 8.0'
         runs_on:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,11 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - "2.7"
           - "3.2"
         include:
-          - ruby-version: '2.7'
-            puppet_gem_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_gem_version: '~> 8.0'
         runs_on:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ inherit_from: .rubocop_todo.yml
 inherit_gem:
   voxpupuli-rubocop: rubocop.yml
 
+AllCops:
+  TargetRubyVersion: '3.1'
+
 # Disabled
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -320,7 +320,7 @@ module RSpec::Puppet
             before_refs = relationship_refs(u, :before) + relationship_refs(u, :notify)
             require_refs = relationship_refs(v, :require) + relationship_refs(u, :subscribe)
 
-            return true if before_refs.include?(v.to_ref) || require_refs.include?(u.to_ref) || (before_refs & require_refs).any?
+            return true if before_refs.include?(v.to_ref) || require_refs.include?(u.to_ref) || before_refs.intersect?(require_refs)
           end
         end
 

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -30,10 +30,10 @@ module RSpec::Puppet
         self
       end
 
-      def only_with(*args, &block)
+      def only_with(*args, &)
         params = args.shift
         @expected_params_count = (@expected_params_count || 0) + params.compact.size
-        with(params, &block)
+        with(params, &)
       end
 
       def without(*args)
@@ -62,7 +62,7 @@ module RSpec::Puppet
         self
       end
 
-      def method_missing(method, *args, &block)
+      def method_missing(method, *args, &)
         case method.to_s
         when /^with_/
           param = method.to_s.gsub(/^with_/, '')

--- a/lib/rspec-puppet/matchers/dynamic_matchers.rb
+++ b/lib/rspec-puppet/matchers/dynamic_matchers.rb
@@ -2,10 +2,10 @@
 
 module RSpec::Puppet
   module ManifestMatchers
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, &)
       if /^(create|contain)_/.match?(method.to_s)
         return RSpec::Puppet::ManifestMatchers::CreateGeneric.new(method, *args,
-                                                                  &block)
+                                                                  &)
       end
       if /^have_.+_count$/.match?(method.to_s)
         return RSpec::Puppet::ManifestMatchers::CountGeneric.new(nil, args[0],
@@ -18,7 +18,7 @@ module RSpec::Puppet
   end
 
   module FunctionMatchers
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, &)
       return RSpec::Puppet::FunctionMatchers::Run.new if method == :run
 
       super
@@ -26,8 +26,8 @@ module RSpec::Puppet
   end
 
   module TypeMatchers
-    def method_missing(method, *args, &block)
-      return RSpec::Puppet::TypeMatchers::CreateGeneric.new(method, *args, &block) if method == :be_valid_type
+    def method_missing(method, ...)
+      return RSpec::Puppet::TypeMatchers::CreateGeneric.new(method, ...) if method == :be_valid_type
 
       super
     end

--- a/lib/rspec-puppet/matchers/raise_error.rb
+++ b/lib/rspec-puppet/matchers/raise_error.rb
@@ -19,9 +19,9 @@ module RSpec::Puppet
     end
 
     def raise_error(
-      error = defined?(RSpec::Matchers::BuiltIn::RaiseError::UndefinedValue) ? RSpec::Matchers::BuiltIn::RaiseError::UndefinedValue : nil, message = nil, &block
+      error = defined?(RSpec::Matchers::BuiltIn::RaiseError::UndefinedValue) ? RSpec::Matchers::BuiltIn::RaiseError::UndefinedValue : nil, message = nil, &
     )
-      RaiseError.new(error, message, &block)
+      RaiseError.new(error, message, &)
     end
   end
 end

--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -143,7 +143,7 @@ module RSpec::Puppet
 
       def failure_message_generic(type, _func_obj)
         # message is mutable
-        message = +"expected #{func_name}(#{func_params}) to "
+        message = "expected #{func_name}(#{func_params}) to "
         message << 'not ' if type == :should_not
 
         if @has_expected_return

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -128,7 +128,7 @@ module RSpec::Puppet
         File.read(path)
       elsif File.directory?(path)
         # Read and concatenate all .pp files.
-        Dir[File.join(path, '*.pp')].sort.map do |f|
+        Dir[File.join(path, '*.pp')].map do |f|
           File.read(f)
         end.join("\n")
       else

--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.authors = ['Tim Sharpe', 'Puppet, Inc.', 'Community Contributors']
   s.email = ['tim@sharpe.id.au', 'modules-team@puppet.com']
 
-  s.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
+  s.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
 end


### PR DESCRIPTION
Puppet 7 is EOL. Therefore, we can remove the test infrastructure for it. This commit aims to clear up any testing/config infrastructure related to Puppet 7 and, by extension, Ruby 2.7.
