### PR TITLE
Add setting to check catalog encoding

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -57,6 +57,7 @@ RSpec.configure do |c|
   c.add_setting :fixture_hiera_configs, default: {}
   c.add_setting :use_fixture_spec_hiera, default: false
   c.add_setting :fallback_to_default_hiera, default: true
+  c.add_setting :strict_catalog_encoding, default: false
 
   c.before(:all) do
     RSpec::Puppet::Setup.safe_setup_directories(nil, false) if RSpec.configuration.setup_fixtures?

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -128,6 +128,8 @@ module RSpec::Puppet
 
         Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(node.facts, catalog)
 
+        check_encoding(catalog)
+
         catalog
       end
 
@@ -179,6 +181,42 @@ module RSpec::Puppet
         impl = impl.call if impl.is_a?(Proc)
         Object.send(:const_set, :FacterImpl, impl)
       end
+
+      # Puppet expects source code to be UTF-8, but other inputs to the
+      # compilation process can cause binary data to be added, which cause
+      # problems later when serializing the catalog as JSON. Warn or raise if
+      # there are any ASCII_8BIT strings or the byte representation does not
+      # match its encoding.
+      #
+      def check_encoding(obj, path = '')
+        case obj
+        when Puppet::Resource::Catalog
+          obj.resources.each do |r|
+            check_encoding(r)
+          end
+        when Puppet::Resource
+          obj.to_hash.each do |param, value|
+            check_encoding(value, "#{obj.type}[#{obj.title}]/#{param}")
+          end
+        when Array
+          obj.each_with_index do |elem, idx|
+            check_encoding(elem, "#{path}[#{idx}]")
+          end
+        when Hash
+          obj.each do |k, v|
+            check_encoding(k, "#{path}/key")
+            check_encoding(v, "#{path}/value")
+          end
+        when String
+          meth = RSpec.configuration.strict_catalog_encoding ? :raise : :warn
+          if obj.encoding == Encoding::ASCII_8BIT
+            send(meth, "#{path} must be wrapped in a Binary data type, not encoded as #{obj.encoding}")
+          elsif !obj.valid_encoding?
+            send(meth, "#{path} is not a valid #{obj.encoding} encoded String")
+          end
+        end
+      end
+      private :check_encoding
     end
 
     def self.get


### PR DESCRIPTION
## Summary

If RSpec.configuration.strict_catalog_encoding is set to true, check whether the catalog contains binary strings or strings with an invalid encoding. This only checks resources, not other catalog metadata like `version`, `environment` or edges.

Binary strings (aka ASCII_8BIT) commonly occur in facts that call Socket.gethostname, Windows registry or partial file reads.

Strings with invalid encodings commonly occur when calling the `file` function to inline kerberos key tab files or DER encoded keys. Note this check can't detect cases where the underlying byte representation happens to be valid for UTF-8. For example, if a string contains the 3 bytes sequence 0xE2 0x82 0xAC, String#valid_encoding? will return true, since that happens to correspond to the € code point. But if the string contains 0xC0, then valid_encoding? will return false, since C0 must be followed by a second byte in UTF-8.

By default the setting is false, because facter has historically produced facts with ASCII_8BIT and will be detected when running "puppet apply". The behavior can be opted into by setting this in your module's spec/spec_helper.rb:

    RSpec.configure do |c|
      c.strict_catalog_encoding = true
    end

## Additional Context

We can't rely on puppet-lint to check for binary data, because we need to evaluate functions and check the resulting catalog that the evaluator produces.
 
## Related Issues (if any)

- https://github.com/puppetlabs/puppet/issues/9255
- https://github.com/puppetlabs/puppet/pull/9042
- https://github.com/puppetlabs/puppetdb/pull/1792
- https://github.com/puppetlabs/puppetdb/pull/1640

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
