### PR TITLE
(CAT-2594) Prepare for Puppetcore 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,17 @@ jobs:
       matrix:
         ruby_version:
           - "3.2"
+          - "4.0"
         include:
           - ruby_version: '3.2'
             puppet_gem_version: '~> 8.0'
+          - ruby_version: '4.0'
+            puppet_gem_version: '~> 9.0'
         runs_on:
           - "ubuntu-latest"
           - "windows-latest"
     name: "spec (${{ matrix.runs_on }} ruby ${{ matrix.ruby_version }} | puppet ${{matrix.puppet_gem_version}})"
-    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@MAINT-Puppet_9_branch_testing"
     secrets: "inherit"
     with:
       rake_task: "spec:coverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - "ubuntu-latest"
           - "windows-latest"
     name: "spec (${{ matrix.runs_on }} ruby ${{ matrix.ruby_version }} | puppet ${{matrix.puppet_gem_version}})"
-    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@MAINT-Puppet_9_branch_testing"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
     with:
       rake_task: "spec:coverage"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,9 +12,12 @@ jobs:
       matrix:
         ruby_version:
           - "3.2"
+          - "4.0"
         include:
           - ruby_version: '3.2'
             puppet_gem_version: '~> 8.0'
+          - ruby_version: '4.0'
+            puppet_gem_version: '~> 9.0'
         runs_on:
           - "ubuntu-latest"
           - "windows-latest"

--- a/Gemfile
+++ b/Gemfile
@@ -24,19 +24,8 @@ group :development do
 end
 
 group :test do
-  # rubocop:disable Bundler/DuplicatedGem
-  if ENV['PUPPET_GEM_VERSION']&.match?(/\A[~> ]*9\./)
-    gem 'facter', git: 'https://github.com/puppetlabs/facter-private', tag: '4.18.0', require: false
-    gem 'puppet', git: 'https://github.com/puppetlabs/puppet-private', branch: 'main', require: false
-    gem 'syslog', require: false
-    gem 'win32ole', require: false, platforms: %i[mingw x64_mingw mswin]
-  else
-    gem 'facter', *location_for(ENV.fetch('FACTER_GEM_VERSION', nil))
-    source 'https://rubygems-puppetcore.puppet.com' do
-      gem 'puppet', '~> 8.0', require: false
-    end
-  end
-  # rubocop:enable Bundler/DuplicatedGem
+  gem 'facter', *location_for(ENV.fetch('FACTER_GEM_VERSION', nil))
+  gem 'puppet', *location_for(ENV.fetch('PUPPET_GEM_VERSION', nil))
 
   gem 'json_pure'
   gem 'sync'

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@
 # For puppetcore, set GEM_SOURCE_PUPPETCORE = 'https://rubygems-puppetcore.puppet.com'
 gemsource_default = ENV['GEM_SOURCE'] || 'https://rubygems.org'
 gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN']
-  'https://rubygems-puppetcore.puppet.com'
-else
-  ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
-end
+                         'https://rubygems-puppetcore.puppet.com'
+                       else
+                         ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
+                       end
 source gemsource_default
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
-source ENV['GEM_SOURCE'] || 'https://rubygems-puppetcore.puppet.com'
+# For puppetcore, set GEM_SOURCE_PUPPETCORE = 'https://rubygems-puppetcore.puppet.com'
+gemsource_default = ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN']
+  'https://rubygems-puppetcore.puppet.com'
+else
+  ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
+end
+source gemsource_default
 
 gemspec
 
-def location_for(place_or_version, fake_version = nil)
+def location_for(place_or_version, fake_version = nil, opts = {})
   git_url_regex = /\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?/
   file_url_regex = %r{\Afile://(?<path>.*)}
 
@@ -13,7 +20,7 @@ def location_for(place_or_version, fake_version = nil)
   elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
     ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
   else
-    [place_or_version, { require: false }]
+    [place_or_version, { require: false }.merge(opts)]
   end
 end
 
@@ -24,8 +31,8 @@ group :development do
 end
 
 group :test do
-  gem 'facter', *location_for(ENV.fetch('FACTER_GEM_VERSION', nil))
-  gem 'puppet', *location_for(ENV.fetch('PUPPET_GEM_VERSION', nil))
+  gem 'facter', *location_for(ENV.fetch('FACTER_GEM_VERSION', nil), nil, { source: gemsource_puppetcore })
+  gem 'puppet', *location_for(ENV.fetch('PUPPET_GEM_VERSION', nil), nil, { source: gemsource_puppetcore })
 
   gem 'json_pure'
   gem 'sync'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || 'https://rubygems-puppetcore.puppet.com'
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,19 @@ group :development do
 end
 
 group :test do
-  gem 'facter', *location_for(ENV.fetch('FACTER_GEM_VERSION', nil))
-  gem 'puppet', *location_for(ENV.fetch('PUPPET_GEM_VERSION', nil))
+  # rubocop:disable Bundler/DuplicatedGem
+  if ENV['PUPPET_GEM_VERSION']&.match?(/\A[~> ]*9\./)
+    gem 'facter', git: 'https://github.com/puppetlabs/facter-private', tag: '4.18.0', require: false
+    gem 'puppet', git: 'https://github.com/puppetlabs/puppet-private', branch: 'main', require: false
+    gem 'syslog', require: false
+    gem 'win32ole', require: false, platforms: %i[mingw x64_mingw mswin]
+  else
+    gem 'facter', *location_for(ENV.fetch('FACTER_GEM_VERSION', nil))
+    source 'https://rubygems-puppetcore.puppet.com' do
+      gem 'puppet', '~> 8.0', require: false
+    end
+  end
+  # rubocop:enable Bundler/DuplicatedGem
 
   gem 'json_pure'
   gem 'sync'


### PR DESCRIPTION
With the arrival of Puppetcore 9, we need to ensure that our tools are compatible with Ruby 4. This commit updates our CI workflow to test against Ruby 4.

## Checklist
- [x] 🟢 Spec tests.
- [x] Manually verified.
